### PR TITLE
feat: AI assistant with intent-based chat, tool calling, and floating widget

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,22 +17,11 @@ NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
 
-# Volvox Assistant — provider switcher
-# Active provider: OpenRouter (free models for development/testing).
-# When ready for production, switch back to Z.AI / GLM in src/lib/ai/provider.ts.
-
-# OpenRouter (active — https://openrouter.ai/keys)
-OPENROUTER_API_KEY=
-# Optional overrides (defaults to the free Kimi K2.6 model):
-OPENROUTER_MODEL=moonshotai/kimi-k2.6:free
-# OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
-
-# Z.AI (Volvox Assistant — production provider, currently disabled in code)
-# Uncomment in src/lib/ai/provider.ts and set this key when going live.
-# Create a key at https://z.ai and copy the value.
+# Volvox Assistant — Z.AI (https://z.ai)
+# Get an API key at https://z.ai and set it below.
 Z_AI_API_KEY=
 # Optional overrides:
-Z_AI_MODEL=glm-4.5
+Z_AI_MODEL=glm-4.5-air
 # Z_AI_BASE_URL=https://api.z.ai/api/paas/v4/
 
 # RevenueCat

--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,24 @@ NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
 
+# Volvox Assistant — provider switcher
+# Active provider: OpenRouter (free models for development/testing).
+# When ready for production, switch back to Z.AI / GLM in src/lib/ai/provider.ts.
+
+# OpenRouter (active — https://openrouter.ai/keys)
+OPENROUTER_API_KEY=
+# Optional overrides (defaults to the free Kimi K2.6 model):
+OPENROUTER_MODEL=moonshotai/kimi-k2.6:free
+# OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+
+# Z.AI (Volvox Assistant — production provider, currently disabled in code)
+# Uncomment in src/lib/ai/provider.ts and set this key when going live.
+# Create a key at https://z.ai and copy the value.
+Z_AI_API_KEY=
+# Optional overrides:
+Z_AI_MODEL=glm-4.5
+# Z_AI_BASE_URL=https://api.z.ai/api/paas/v4/
+
 # RevenueCat
 # Public SDK API keys for in-app purchases (use platform-specific keys)
 # Get these from RevenueCat Dashboard > Project Settings > API keys > App specific keys

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,9 @@ test-results/
 worktrees/
 .worktrees/
 .automaker/
+
+# AI agent scratch files
+.antigravitycli/
+.impeccable/
+DESIGN.md
+PRODUCT.md

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     ]
   },
   "dependencies": {
+    "@ai-sdk/openai": "^3.0.67",
+    "@ai-sdk/openai-compatible": "^2.0.48",
+    "@ai-sdk/react": "^3.0.198",
     "@next/third-parties": "^16.2.6",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-avatar": "^1.1.11",
@@ -30,9 +33,11 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-visually-hidden": "^1.2.4",
     "@sentry/nextjs": "^10.53.1",
+    "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.38.0",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
+    "ai": "^6.0.196",
     "canvas-confetti": "^1.9.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,15 @@ importers:
 
   .:
     dependencies:
+      '@ai-sdk/openai':
+        specifier: ^3.0.67
+        version: 3.0.67(zod@4.4.3)
+      '@ai-sdk/openai-compatible':
+        specifier: ^2.0.48
+        version: 2.0.48(zod@4.4.3)
+      '@ai-sdk/react':
+        specifier: ^3.0.198
+        version: 3.0.198(react@19.2.6)(zod@4.4.3)
       '@next/third-parties':
         specifier: ^16.2.6
         version: 16.2.6(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
@@ -39,6 +48,9 @@ importers:
       '@sentry/nextjs':
         specifier: ^10.53.1
         version: 10.53.1(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(webpack@5.106.2(postcss@8.5.14))
+      '@upstash/ratelimit':
+        specifier: ^2.0.8
+        version: 2.0.8(@upstash/redis@1.38.0)
       '@upstash/redis':
         specifier: ^1.38.0
         version: 1.38.0
@@ -48,6 +60,9 @@ importers:
       '@vercel/speed-insights':
         specifier: ^2.0.0
         version: 2.0.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      ai:
+        specifier: ^6.0.196
+        version: 6.0.196(zod@4.4.3)
       canvas-confetti:
         specifier: ^1.9.4
         version: 1.9.4
@@ -183,6 +198,40 @@ packages:
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@ai-sdk/gateway@3.0.124':
+    resolution: {integrity: sha512-h8CrmbSG+8X0C+M/E1M4oiDHYevqwbzAPN+uLRHS0eJaatF2MZ+juNtOHXNOjk7Bsk9mD2RjYMjJO9dFkb9I7Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai-compatible@2.0.48':
+    resolution: {integrity: sha512-z9MC6M4Oh/yUY/F/eszOtO8wc2nMz99XmZQKd2gWTtyIfe716xTfrKe3aYZKg20NZDtyjqPPKPSR+wqz7q1T7Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai@3.0.67':
+    resolution: {integrity: sha512-oAiGC9eWG7IgtdsdS74bOCnAAHarAfTJhWN9x5INwnWPekL802AvF+0I5DvLzIF1MIRmNw4N8mPSL/GUVbX9Mw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.27':
+    resolution: {integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.10':
+    resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/react@3.0.198':
+    resolution: {integrity: sha512-ozlxMidzvKXAefvnq95Y34rJ5MipXABIv1bg2RLEnWUBxGrKxNHrYl0fTfi6grTN88wSXMZYaMY2oHMCHDFuJw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -1608,6 +1657,9 @@ packages:
   '@sinclair/typebox@0.34.49':
     resolution: {integrity: sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -1833,6 +1885,15 @@ packages:
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
+  '@upstash/core-analytics@0.0.10':
+    resolution: {integrity: sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==}
+    engines: {node: '>=16.0.0'}
+
+  '@upstash/ratelimit@2.0.8':
+    resolution: {integrity: sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==}
+    peerDependencies:
+      '@upstash/redis': ^1.34.3
+
   '@upstash/redis@1.38.0':
     resolution: {integrity: sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==}
 
@@ -1864,6 +1925,10 @@ packages:
         optional: true
       vue-router:
         optional: true
+
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
 
   '@vercel/speed-insights@2.0.0':
     resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
@@ -1970,6 +2035,12 @@ packages:
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
+
+  ai@6.0.196:
+    resolution: {integrity: sha512-2T45UeqKL4a11KQ14I5i1YYHOvCFrMF478E1k6PVjlQSGUvXSv4xrxIaQbUL4qgv91DADSbddwv3oR49pPAK3g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
@@ -2277,6 +2348,10 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
   expect@30.4.1:
     resolution: {integrity: sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -2488,6 +2563,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -3253,6 +3331,11 @@ packages:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
 
+  swr@2.4.1:
+    resolution: {integrity: sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   tailwind-merge@3.6.0:
     resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
 
@@ -3313,6 +3396,10 @@ packages:
 
   third-party-capital@1.0.20:
     resolution: {integrity: sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==}
+
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
 
   tinyexec@1.1.2:
     resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
@@ -3500,6 +3587,46 @@ packages:
 snapshots:
 
   '@adobe/css-tools@4.4.4': {}
+
+  '@ai-sdk/gateway@3.0.124(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
+      zod: 4.4.3
+
+  '@ai-sdk/openai-compatible@2.0.48(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/openai@3.0.67(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@4.0.27(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider@3.0.10':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/react@3.0.198(react@19.2.6)(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      ai: 6.0.196(zod@4.4.3)
+      react: 19.2.6
+      swr: 2.4.1(react@19.2.6)
+      throttleit: 2.1.0
+    transitivePeerDependencies:
+      - zod
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -4812,6 +4939,8 @@ snapshots:
 
   '@sinclair/typebox@0.34.49': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -5026,6 +5155,15 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
+  '@upstash/core-analytics@0.0.10':
+    dependencies:
+      '@upstash/redis': 1.38.0
+
+  '@upstash/ratelimit@2.0.8(@upstash/redis@1.38.0)':
+    dependencies:
+      '@upstash/core-analytics': 0.0.10
+      '@upstash/redis': 1.38.0
+
   '@upstash/redis@1.38.0':
     dependencies:
       uncrypto: 0.1.3
@@ -5034,6 +5172,8 @@ snapshots:
     optionalDependencies:
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
+
+  '@vercel/oidc@3.2.0': {}
 
   '@vercel/speed-insights@2.0.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     optionalDependencies:
@@ -5143,6 +5283,14 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  ai@6.0.196(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.124(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      '@opentelemetry/api': 1.9.1
+      zod: 4.4.3
 
   ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:
@@ -5422,6 +5570,8 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.1.0: {}
+
   expect@30.4.1:
     dependencies:
       '@jest/expect-utils': 30.4.1
@@ -5668,6 +5818,8 @@ snapshots:
   jsesc@3.1.0: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema@0.4.0: {}
 
   json5@2.2.3: {}
 
@@ -6748,6 +6900,12 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  swr@2.4.1(react@19.2.6):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.6
+      use-sync-external-store: 1.6.0(react@19.2.6)
+
   tailwind-merge@3.6.0: {}
 
   tailwindcss@4.3.0: {}
@@ -6772,6 +6930,8 @@ snapshots:
       source-map-support: 0.5.21
 
   third-party-capital@1.0.20: {}
+
+  throttleit@2.1.0: {}
 
   tinyexec@1.1.2: {}
 

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -9,7 +9,7 @@ import {
 import { z } from "zod";
 import type { VisitorIntent } from "@/lib/ai/intent";
 import { detectIntent } from "@/lib/ai/intent";
-import { chatModel } from "@/lib/ai/provider";
+import { getChatModel } from "@/lib/ai/provider";
 import { assertChatRateLimit, type RateLimitResult } from "@/lib/ai/rate-limit";
 import { buildSystemPrompt } from "@/lib/ai/system-prompt";
 import { aiTools } from "@/lib/ai/tools";
@@ -133,7 +133,7 @@ export async function POST(req: Request) {
       });
 
       const result = streamText({
-        model: chatModel,
+        model: getChatModel(),
         system,
         messages: modelMessages,
         tools: aiTools,

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,0 +1,149 @@
+import type { UIMessage } from "ai";
+import {
+  convertToModelMessages,
+  createUIMessageStream,
+  createUIMessageStreamResponse,
+  stepCountIs,
+  streamText,
+} from "ai";
+import { z } from "zod";
+import type { VisitorIntent } from "@/lib/ai/intent";
+import { detectIntent } from "@/lib/ai/intent";
+import { chatModel } from "@/lib/ai/provider";
+import { assertChatRateLimit, type RateLimitResult } from "@/lib/ai/rate-limit";
+import { buildSystemPrompt } from "@/lib/ai/system-prompt";
+import { aiTools } from "@/lib/ai/tools";
+import { reportError } from "@/lib/logger";
+
+export const runtime = "nodejs";
+export const maxDuration = 30;
+
+const INTENT_SEED_VALUES = ["beginner", "professional", "hirer"] as const;
+
+const ChatRequestSchema = z.object({
+  messages: z.array(z.any()).min(1).max(50),
+  intentSeed: z.enum(INTENT_SEED_VALUES).optional().nullable(),
+});
+
+function isUIMessage(value: unknown): value is UIMessage {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "role" in value &&
+    "id" in value &&
+    typeof (value as { id?: unknown }).id === "string"
+  );
+}
+
+export async function POST(req: Request) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return new Response("Invalid JSON", { status: 400 });
+  }
+
+  const parsed = ChatRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return new Response("Invalid request shape", { status: 400 });
+  }
+
+  const rawMessages = parsed.data.messages.filter(isUIMessage);
+  if (rawMessages.length === 0) {
+    return new Response("No messages provided", { status: 400 });
+  }
+
+  const ipHeader = req.headers.get("x-forwarded-for") ?? "";
+  const ip = ipHeader.split(",")[0]?.trim() || "anon";
+
+  let rateLimit: RateLimitResult;
+  try {
+    rateLimit = await assertChatRateLimit(ip);
+  } catch (err) {
+    reportError("Chat rate limit threw", err);
+    rateLimit = { success: true, limit: 20, remaining: 20, reset: 0 };
+  }
+
+  if (!rateLimit.success) {
+    return new Response(
+      JSON.stringify({
+        error: "rate_limited",
+        message:
+          "You're sending messages too fast. Take a breath and try again in a moment.",
+        reset: rateLimit.reset,
+      }),
+      {
+        status: 429,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  const userTextFromMessages: string[] = [];
+  for (const m of rawMessages) {
+    if (m.role !== "user") continue;
+    const parts = (m as { parts?: unknown }).parts;
+    if (Array.isArray(parts)) {
+      const text = parts
+        .map((p) => {
+          if (typeof p !== "object" || p === null) return "";
+          const t = (p as { text?: unknown }).text;
+          return typeof t === "string" ? t : "";
+        })
+        .join(" ")
+        .trim();
+      if (text) userTextFromMessages.push(text);
+    }
+  }
+
+  const seed: VisitorIntent | null = parsed.data.intentSeed ?? null;
+  const detection = detectIntent(
+    userTextFromMessages.map((content) => ({ role: "user", content })),
+    { explicitSeed: seed },
+  );
+
+  const system = buildSystemPrompt(detection.intent);
+
+  let modelMessages: Awaited<ReturnType<typeof convertToModelMessages>>;
+  try {
+    modelMessages = await convertToModelMessages(rawMessages);
+  } catch (err) {
+    reportError("Failed to convert UI messages to model messages", err);
+    return new Response("Failed to process messages", { status: 400 });
+  }
+
+  const stream = createUIMessageStream({
+    originalMessages: rawMessages,
+    execute: async ({ writer }) => {
+      writer.write({
+        type: "data-chat-meta",
+        data: {
+          intent: detection.intent,
+          confidence: detection.confidence,
+          signals: detection.signals,
+          rateLimitRemaining: rateLimit.remaining,
+        },
+        transient: true,
+      });
+
+      const result = streamText({
+        model: chatModel,
+        system,
+        messages: modelMessages,
+        tools: aiTools,
+        stopWhen: stepCountIs(6),
+        onError: ({ error }) => {
+          reportError("Chat stream error", error);
+        },
+      });
+
+      writer.merge(result.toUIMessageStream());
+    },
+    onError: (error) => {
+      reportError("Chat stream fatal", error);
+      return "Something went sideways on our side. Try sending that again.";
+    },
+  });
+
+  return createUIMessageStreamResponse({ stream });
+}

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -53,8 +53,14 @@ export async function POST(req: Request) {
     return new Response("No messages provided", { status: 400 });
   }
 
-  const ipHeader = req.headers.get("x-forwarded-for") ?? "";
-  const ip = ipHeader.split(",")[0]?.trim() || "anon";
+  const vercelForwarded = req.headers.get("x-vercel-forwarded-for") ?? "";
+  const realIp = req.headers.get("x-real-ip") ?? "";
+  const forwardedFor = req.headers.get("x-forwarded-for") ?? "";
+  const ip =
+    vercelForwarded.split(",")[0]?.trim() ||
+    realIp.split(",")[0]?.trim() ||
+    forwardedFor.split(",")[0]?.trim() ||
+    "anon";
 
   let rateLimit: RateLimitResult;
   try {

--- a/src/app/chat/chat-page-client.tsx
+++ b/src/app/chat/chat-page-client.tsx
@@ -1,8 +1,5 @@
 "use client";
 
-import { ArrowLeft, ChatsCircle, Sparkle } from "@phosphor-icons/react";
-import Image from "next/image";
-import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useRef } from "react";
 import { ChatPanel } from "@/components/ai/chat-panel";
@@ -60,94 +57,8 @@ export function ChatPageClient() {
     <ChatProvider>
       <PageInner />
       <main className="relative flex h-[100dvh] min-h-0 flex-col overflow-hidden bg-background">
-        <div
-          className="pointer-events-none absolute -top-[28vw] left-1/2 h-[72vw] w-[72vw] -translate-x-1/2 rounded-full opacity-70 blur-3xl"
-          style={{
-            background:
-              "radial-gradient(circle, oklch(from var(--primary) l c h / 0.18) 0%, transparent 68%)",
-          }}
-        />
-
-        <header className="relative z-10 flex shrink-0 justify-center px-3 pt-3 sm:px-6 sm:pt-6">
-          <nav className="flex w-full max-w-6xl items-center justify-between rounded-full border border-foreground/[0.08] bg-background/55 px-3 py-2 shadow-[0_10px_30px_-5px_rgba(0,0,0,0.12)] backdrop-blur-xl sm:px-5">
-            <Link
-              href="/"
-              className="flex items-center gap-3 no-underline"
-              aria-label="Back to Volvox home"
-            >
-              <Image
-                src="/logo.png"
-                alt=""
-                width={32}
-                height={32}
-                className="h-8 w-8 rounded-md object-contain"
-                priority
-              />
-              <span className="hidden font-[family-name:var(--font-jetbrains-mono)] text-sm font-bold text-foreground sm:inline">
-                Volvox
-              </span>
-            </Link>
-            <div className="flex items-center gap-2 rounded-full bg-foreground/5 px-3 py-1.5 text-xs font-semibold text-foreground/75">
-              <ChatsCircle className="h-4 w-4 text-primary" weight="fill" />
-              Ask Volvox
-            </div>
-            <Link
-              href="/"
-              className="inline-flex h-9 w-9 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-foreground/5 hover:text-foreground sm:w-auto sm:gap-2 sm:px-3"
-              aria-label="Back to site"
-            >
-              <ArrowLeft className="h-4 w-4" />
-              <span className="hidden text-xs font-semibold sm:inline">
-                Back
-              </span>
-            </Link>
-          </nav>
-        </header>
-
-        <div className="relative z-10 mx-auto grid w-full max-w-6xl flex-1 min-h-0 grid-cols-1 gap-4 px-3 py-4 sm:px-6 sm:py-6 lg:grid-cols-[0.82fr_1.18fr]">
-          <aside className="hidden min-h-0 flex-col justify-between rounded-[32px] bg-card p-2 lg:flex">
-            <div className="relative min-h-[340px] overflow-hidden rounded-[24px] bg-background">
-              <div
-                className="absolute -top-20 left-1/2 h-80 w-80 -translate-x-1/2 rounded-full opacity-80 blur-3xl"
-                style={{
-                  background:
-                    "radial-gradient(circle, oklch(from var(--primary) l c h / 0.22), transparent 70%)",
-                }}
-              />
-              <div className="absolute inset-x-0 bottom-0 h-44 overflow-hidden rounded-[24px]">
-                <div className="absolute inset-0 backdrop-blur-[9px] [mask-image:linear-gradient(to_top,black_0%,transparent_100%)]" />
-                <div className="absolute inset-0 backdrop-blur-[18px] [mask-image:linear-gradient(to_top,black_0%,transparent_60%)]" />
-                <div className="absolute inset-0 bg-gradient-to-t from-background via-background/50 to-transparent" />
-              </div>
-              <div className="relative z-10 flex h-full min-h-[340px] flex-col justify-between p-8">
-                <div className="inline-flex w-fit items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-3 py-1.5 text-xs font-semibold text-primary">
-                  <Sparkle className="h-3.5 w-3.5" weight="fill" />
-                  Community intelligence
-                </div>
-                <div className="space-y-5">
-                  <h1 className="font-[family-name:var(--font-jetbrains-mono)] text-4xl font-extrabold leading-[1.1] tracking-tight text-foreground">
-                    Ask about the people, products, and path in.
-                  </h1>
-                  <p className="max-w-[36ch] text-sm leading-relaxed text-foreground/70">
-                    The assistant answers from Volvox content and points you to
-                    the right project, post, profile, or community next step.
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div className="grid grid-cols-3 gap-2 p-2 pt-4">
-              {["Products", "Team", "Mentorship"].map((item) => (
-                <div
-                  key={item}
-                  className="rounded-full border border-border/40 bg-background/60 px-3 py-2 text-center text-[11px] font-semibold text-muted-foreground"
-                >
-                  {item}
-                </div>
-              ))}
-            </div>
-          </aside>
-
-          <section className="min-h-0">
+        <div className="relative z-10 flex flex-1 min-h-0">
+          <section className="w-full h-full min-h-0">
             <ChatPanel variant="fullscreen" />
           </section>
         </div>

--- a/src/app/chat/chat-page-client.tsx
+++ b/src/app/chat/chat-page-client.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { ArrowLeft, ChatsCircle, Sparkle } from "@phosphor-icons/react";
+import Image from "next/image";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { useEffect } from "react";
+import { ChatPanel } from "@/components/ai/chat-panel";
+import { ChatProvider, useChatContext } from "@/components/ai/chat-provider";
+import type { VisitorIntent } from "@/lib/ai/types";
+
+const INTENT_VALUES = new Set<VisitorIntent>([
+  "beginner",
+  "professional",
+  "hirer",
+]);
+
+function PageInner() {
+  const params = useSearchParams();
+  const { sendMessage, setExplicitSeed } = useChatContext();
+  const intentParam = params.get("intent");
+  const promptParam = params.get("q");
+
+  useEffect(() => {
+    if (intentParam && INTENT_VALUES.has(intentParam as VisitorIntent)) {
+      setExplicitSeed(intentParam as VisitorIntent);
+    }
+  }, [intentParam, setExplicitSeed]);
+
+  useEffect(() => {
+    if (!promptParam) return;
+    const timer = setTimeout(() => {
+      sendMessage({ text: promptParam });
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [promptParam, sendMessage]);
+
+  return null;
+}
+
+export function ChatPageClient() {
+  return (
+    <ChatProvider>
+      <PageInner />
+      <main className="relative flex h-[100dvh] min-h-0 flex-col overflow-hidden bg-background">
+        <div
+          className="pointer-events-none absolute -top-[28vw] left-1/2 h-[72vw] w-[72vw] -translate-x-1/2 rounded-full opacity-70 blur-3xl"
+          style={{
+            background:
+              "radial-gradient(circle, oklch(from var(--primary) l c h / 0.18) 0%, transparent 68%)",
+          }}
+        />
+
+        <header className="relative z-10 flex shrink-0 justify-center px-3 pt-3 sm:px-6 sm:pt-6">
+          <nav className="flex w-full max-w-6xl items-center justify-between rounded-full border border-foreground/[0.08] bg-background/55 px-3 py-2 shadow-[0_10px_30px_-5px_rgba(0,0,0,0.12)] backdrop-blur-xl sm:px-5">
+            <Link
+              href="/"
+              className="flex items-center gap-3 no-underline"
+              aria-label="Back to Volvox home"
+            >
+              <Image
+                src="/logo.png"
+                alt=""
+                width={32}
+                height={32}
+                className="h-8 w-8 rounded-md object-contain"
+                priority
+              />
+              <span className="hidden font-[family-name:var(--font-jetbrains-mono)] text-sm font-bold text-foreground sm:inline">
+                Volvox
+              </span>
+            </Link>
+            <div className="flex items-center gap-2 rounded-full bg-foreground/5 px-3 py-1.5 text-xs font-semibold text-foreground/75">
+              <ChatsCircle className="h-4 w-4 text-primary" weight="fill" />
+              Ask Volvox
+            </div>
+            <Link
+              href="/"
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-foreground/5 hover:text-foreground sm:w-auto sm:gap-2 sm:px-3"
+              aria-label="Back to site"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              <span className="hidden text-xs font-semibold sm:inline">
+                Back
+              </span>
+            </Link>
+          </nav>
+        </header>
+
+        <div className="relative z-10 mx-auto grid w-full max-w-6xl flex-1 min-h-0 grid-cols-1 gap-4 px-3 py-4 sm:px-6 sm:py-6 lg:grid-cols-[0.82fr_1.18fr]">
+          <aside className="hidden min-h-0 flex-col justify-between rounded-[32px] bg-card p-2 lg:flex">
+            <div className="relative min-h-[340px] overflow-hidden rounded-[24px] bg-background">
+              <div
+                className="absolute -top-20 left-1/2 h-80 w-80 -translate-x-1/2 rounded-full opacity-80 blur-3xl"
+                style={{
+                  background:
+                    "radial-gradient(circle, oklch(from var(--primary) l c h / 0.22), transparent 70%)",
+                }}
+              />
+              <div className="absolute inset-x-0 bottom-0 h-44 overflow-hidden rounded-[24px]">
+                <div className="absolute inset-0 backdrop-blur-[9px] [mask-image:linear-gradient(to_top,black_0%,transparent_100%)]" />
+                <div className="absolute inset-0 backdrop-blur-[18px] [mask-image:linear-gradient(to_top,black_0%,transparent_60%)]" />
+                <div className="absolute inset-0 bg-gradient-to-t from-background via-background/50 to-transparent" />
+              </div>
+              <div className="relative z-10 flex h-full min-h-[340px] flex-col justify-between p-8">
+                <div className="inline-flex w-fit items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-3 py-1.5 text-xs font-semibold text-primary">
+                  <Sparkle className="h-3.5 w-3.5" weight="fill" />
+                  Community intelligence
+                </div>
+                <div className="space-y-5">
+                  <h1 className="font-[family-name:var(--font-jetbrains-mono)] text-4xl font-extrabold leading-[1.1] tracking-tight text-foreground">
+                    Ask about the people, products, and path in.
+                  </h1>
+                  <p className="max-w-[36ch] text-sm leading-relaxed text-foreground/70">
+                    The assistant answers from Volvox content and points you to
+                    the right project, post, profile, or community next step.
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div className="grid grid-cols-3 gap-2 p-2 pt-4">
+              {["Products", "Team", "Mentorship"].map((item) => (
+                <div
+                  key={item}
+                  className="rounded-full border border-border/40 bg-background/60 px-3 py-2 text-center text-[11px] font-semibold text-muted-foreground"
+                >
+                  {item}
+                </div>
+              ))}
+            </div>
+          </aside>
+
+          <section className="min-h-0">
+            <ChatPanel variant="fullscreen" />
+          </section>
+        </div>
+      </main>
+    </ChatProvider>
+  );
+}

--- a/src/app/chat/chat-page-client.tsx
+++ b/src/app/chat/chat-page-client.tsx
@@ -4,7 +4,7 @@ import { ArrowLeft, ChatsCircle, Sparkle } from "@phosphor-icons/react";
 import Image from "next/image";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { ChatPanel } from "@/components/ai/chat-panel";
 import { ChatProvider, useChatContext } from "@/components/ai/chat-provider";
 import type { VisitorIntent } from "@/lib/ai/types";
@@ -17,9 +17,11 @@ const INTENT_VALUES = new Set<VisitorIntent>([
 
 function PageInner() {
   const params = useSearchParams();
-  const { sendMessage, setExplicitSeed } = useChatContext();
+  const { sendMessage, setExplicitSeed, messages, storageLoaded } =
+    useChatContext();
   const intentParam = params.get("intent");
   const promptParam = params.get("q");
+  const sentRef = useRef(false);
 
   useEffect(() => {
     if (intentParam && INTENT_VALUES.has(intentParam as VisitorIntent)) {
@@ -28,12 +30,27 @@ function PageInner() {
   }, [intentParam, setExplicitSeed]);
 
   useEffect(() => {
-    if (!promptParam) return;
+    if (!promptParam || sentRef.current || !storageLoaded) return;
+    const alreadySent = messages.some(
+      (m) =>
+        m.role === "user" &&
+        m.parts?.some(
+          (p) =>
+            typeof p === "object" &&
+            p !== null &&
+            "type" in p &&
+            p.type === "text" &&
+            "text" in p &&
+            (p as { text: string }).text === promptParam,
+        ),
+    );
+    if (alreadySent) return;
+    sentRef.current = true;
     const timer = setTimeout(() => {
       sendMessage({ text: promptParam });
     }, 300);
     return () => clearTimeout(timer);
-  }, [promptParam, sendMessage]);
+  }, [promptParam, sendMessage, messages, storageLoaded]);
 
   return null;
 }

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import { ChatPageClient } from "./chat-page-client";
+
+export const metadata: Metadata = {
+  title: "Ask Volvox",
+  description:
+    "Chat with the Volvox Assistant. Ask about our team, products, and community — the assistant adapts to your question.",
+  robots: {
+    index: false,
+    follow: true,
+  },
+};
+
+export default function ChatPage() {
+  return (
+    <Suspense fallback={null}>
+      <ChatPageClient />
+    </Suspense>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -37,6 +37,11 @@
   --radius-lg: var(--radius);
   --radius-md: calc(var(--radius) - 2px);
   --radius-sm: calc(var(--radius) - 4px);
+  --radius-xl: calc(var(--radius) + 0.25rem);
+  --radius-2xl: calc(var(--radius) + 0.75rem);
+  --radius-3xl: calc(var(--radius) + 1.25rem);
+  --radius-4xl: calc(var(--radius) + 2rem);
+  --radius-5xl: calc(var(--radius) + 3rem);
 
   /* Animations */
   --ease-*: initial;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { JetBrains_Mono, Manrope, Space_Grotesk } from "next/font/google";
 import "./globals.css";
 import "highlight.js/styles/github-dark.css";
+import { VolvoxAssistant } from "@/components/ai/volvox-assistant";
 import { ConditionalAnalytics } from "@/components/conditional-analytics";
 import { CookieConsentBanner } from "@/components/cookie-consent-banner";
 import { CookieConsentProvider } from "@/components/providers/cookie-consent-provider";
@@ -114,6 +115,7 @@ export default function RootLayout({
               {children}
               <Toaster />
               <CookieConsentBanner />
+              <VolvoxAssistant />
             </ThemeProvider>
             <ConditionalAnalytics />
           </CookieConsentProvider>

--- a/src/components/ai/chat-blog-card.tsx
+++ b/src/components/ai/chat-blog-card.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { ArrowSquareOut, Clock } from "@phosphor-icons/react";
+import Link from "next/link";
+
+interface ChatBlogCardProps {
+  slug: string;
+  reason: string;
+  title?: string;
+  excerpt?: string;
+  authorName?: string;
+  readingTime?: number;
+  url?: string;
+}
+
+export function ChatBlogCard({
+  slug,
+  reason,
+  title,
+  excerpt,
+  authorName,
+  readingTime,
+  url,
+}: ChatBlogCardProps) {
+  const link = url ?? `/blog/${slug}`;
+  const displayTitle = title ?? slug;
+
+  return (
+    <div className="group relative my-2 overflow-hidden rounded-2xl border border-border/50 bg-gradient-to-br from-card/80 to-card/40 p-3 backdrop-blur-sm">
+      <div className="space-y-1.5">
+        <h4 className="line-clamp-2 text-sm font-semibold leading-snug text-foreground">
+          {displayTitle}
+        </h4>
+        <p className="line-clamp-2 text-xs leading-relaxed text-foreground/70">
+          {reason || excerpt}
+        </p>
+        <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+          {authorName && <span>{authorName}</span>}
+          {authorName && readingTime && <span>·</span>}
+          {readingTime && readingTime > 0 && (
+            <span className="inline-flex items-center gap-0.5">
+              <Clock className="h-2.5 w-2.5" />
+              {readingTime} min
+            </span>
+          )}
+        </div>
+      </div>
+      <Link
+        href={link}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="mt-3 inline-flex w-full items-center justify-center gap-1.5 rounded-full bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+      >
+        Read post
+        <ArrowSquareOut className="h-3 w-3" weight="bold" />
+      </Link>
+    </div>
+  );
+}

--- a/src/components/ai/chat-header.tsx
+++ b/src/components/ai/chat-header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ArrowSquareOut, Trash, X } from "@phosphor-icons/react";
+import Image from "next/image";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 
@@ -18,13 +19,35 @@ export function ChatHeader({
   variant,
 }: ChatHeaderProps) {
   return (
-    <div className="flex items-center justify-between px-3 sm:px-4">
+    <div className="flex items-center justify-between px-3 sm:px-4 mx-auto max-w-4xl">
       <div className="flex items-center gap-2">
-        <h2 className="font-[family-name:var(--font-jetbrains-mono)] text-sm font-bold tracking-tight sm:text-[15px]">
-          VOLVOX.BOT
-        </h2>
-        {isStreaming && (
-          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-primary/60" />
+        {variant === "fullscreen" ? (
+          <Link
+            href="/"
+            className="flex items-center gap-2 no-underline"
+            aria-label="Back to Volvox home"
+          >
+            <Image
+              src="/logo.png"
+              alt=""
+              width={24}
+              height={24}
+              className="h-6 w-6 rounded-md object-contain"
+              priority
+            />
+            <h2 className="font-[family-name:var(--font-jetbrains-mono)] text-sm font-bold tracking-tight sm:text-[15px]">
+              VOLVOX.BOT
+            </h2>
+          </Link>
+        ) : (
+          <>
+            <h2 className="font-[family-name:var(--font-jetbrains-mono)] text-sm font-bold tracking-tight sm:text-[15px]">
+              VOLVOX.BOT
+            </h2>
+            {isStreaming && (
+              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-primary/60" />
+            )}
+          </>
         )}
       </div>
 

--- a/src/components/ai/chat-header.tsx
+++ b/src/components/ai/chat-header.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { ArrowSquareOut, Trash, X } from "@phosphor-icons/react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+interface ChatHeaderProps {
+  variant?: "floating" | "fullscreen";
+  onClose?: () => void;
+  onClear: () => void;
+  isStreaming: boolean;
+}
+
+export function ChatHeader({
+  onClose,
+  onClear,
+  isStreaming,
+  variant,
+}: ChatHeaderProps) {
+  return (
+    <div className="flex items-center justify-between px-3 sm:px-4">
+      <div className="flex items-center gap-2">
+        <h2 className="font-[family-name:var(--font-jetbrains-mono)] text-sm font-bold tracking-tight sm:text-[15px]">
+          VOLVOX.BOT
+        </h2>
+        {isStreaming && (
+          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-primary/60" />
+        )}
+      </div>
+
+      <div className="flex items-center gap-1">
+        {variant === "floating" && (
+          <Button
+            variant="text"
+            size="icon"
+            shape="square"
+            className="text-muted-foreground hover:text-foreground"
+            title="Open full page"
+            asChild
+          >
+            <Link href="/chat">
+              <ArrowSquareOut className="h-4 w-4" />
+            </Link>
+          </Button>
+        )}
+        <Button
+          variant="text"
+          size="icon"
+          shape="square"
+          onClick={onClear}
+          title="Clear conversation"
+          className="text-muted-foreground hover:text-foreground"
+        >
+          <Trash className="h-4 w-4" />
+        </Button>
+        {onClose && (
+          <Button
+            variant="text"
+            size="icon"
+            shape="square"
+            onClick={onClose}
+            title="Close assistant"
+            className="text-muted-foreground hover:text-foreground"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ai/chat-input.tsx
+++ b/src/components/ai/chat-input.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { ArrowUp, Stop } from "@phosphor-icons/react";
+import { useEffect, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { useChatContext } from "./chat-provider";
+
+interface ChatInputProps {
+  floating?: boolean;
+}
+
+export function ChatInput({ floating }: ChatInputProps) {
+  const { sendMessage, status, stop } = useChatContext();
+  const isStreaming = status === "streaming" || status === "submitted";
+  const isDisabled = status === "error";
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const formRef = useRef<HTMLFormElement>(null);
+
+  useEffect(() => {
+    const ta = inputRef.current;
+    if (!ta) return;
+    ta.style.height = "auto";
+    const next = Math.min(ta.scrollHeight, 160);
+    ta.style.height = `${next}px`;
+  }, []);
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (isStreaming) return;
+    const form = e.currentTarget;
+    const data = new FormData(form);
+    const text = String(data.get("message") ?? "").trim();
+    if (!text) return;
+    sendMessage({ text });
+    form.reset();
+    if (inputRef.current) {
+      inputRef.current.style.height = "auto";
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      formRef.current?.requestSubmit();
+    }
+  };
+
+  return (
+    <form
+      ref={formRef}
+      onSubmit={handleSubmit}
+      data-lenis-prevent
+      className={cn(
+        "transition-[border-color,background-color]",
+        floating
+          ? "px-3 pb-3 pt-0 sm:px-4 sm:pb-4"
+          : "border-t border-border/40 bg-card p-3 sm:p-4",
+      )}
+    >
+      <div className="flex items-end gap-2 rounded-[24px] border border-border/60 bg-background p-2 transition-[border-color,box-shadow] focus-within:border-primary/50 focus-within:shadow-[0_4px_15px_oklch(from_var(--primary)_l_c_h_/_0.22)]">
+        <textarea
+          ref={inputRef}
+          name="message"
+          placeholder="Ask about Volvox, our team, or products..."
+          rows={1}
+          disabled={isDisabled}
+          onKeyDown={handleKeyDown}
+          className={cn(
+            "no-ring min-h-[28px] flex-1 resize-none bg-transparent px-2 py-1.5 text-sm leading-relaxed text-foreground",
+            "placeholder:text-muted-foreground/60",
+            "disabled:cursor-not-allowed disabled:opacity-50",
+          )}
+          aria-label="Message Volvox Assistant"
+        />
+        {isStreaming ? (
+          <button
+            type="button"
+            onClick={stop}
+            className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-destructive text-destructive-foreground transition-[opacity,border-radius] hover:opacity-90 active:rounded-xl"
+            aria-label="Stop generating"
+          >
+            <Stop className="h-4 w-4" weight="fill" />
+          </button>
+        ) : (
+          <button
+            type="submit"
+            className={cn(
+              "flex h-10 w-10 shrink-0 items-center justify-center rounded-full transition-[opacity,border-radius]",
+              "bg-primary text-primary-foreground",
+              "hover:opacity-90 active:rounded-xl",
+            )}
+            aria-label="Send message"
+          >
+            <ArrowUp className="h-4 w-4" weight="bold" />
+          </button>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/src/components/ai/chat-input.tsx
+++ b/src/components/ai/chat-input.tsx
@@ -51,13 +51,13 @@ export function ChatInput({ floating }: ChatInputProps) {
       onSubmit={handleSubmit}
       data-lenis-prevent
       className={cn(
-        "transition-[border-color,background-color]",
+        "transition-[border-color,background-color] mx-auto w-full max-w-4xl",
         floating
           ? "px-3 pb-3 pt-0 sm:px-4 sm:pb-4"
-          : "border-t border-border/40 bg-card p-3 sm:p-4",
+          : "border-t border-border/40 bg-transparent p-3 sm:p-4",
       )}
     >
-      <div className="flex items-end gap-2 rounded-[24px] border border-border/60 bg-background p-2 transition-[border-color,box-shadow] focus-within:border-primary/50 focus-within:shadow-[0_4px_15px_oklch(from_var(--primary)_l_c_h_/_0.22)]">
+      <div className="flex items-end gap-2 rounded-[24px] border border-border/60 bg-background p-2 transition-[border-color,box-shadow] focus-within:border-primary/50 focus-within:bg-background focus-within:shadow-[0_4px_15px_oklch(from_var(--primary)_l_c_h_/_0.22)]">
         <textarea
           ref={inputRef}
           name="message"

--- a/src/components/ai/chat-markdown.tsx
+++ b/src/components/ai/chat-markdown.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { memo, useMemo } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+interface ChatMarkdownProps {
+  content: string;
+}
+
+function MarkdownImpl({ content }: ChatMarkdownProps) {
+  const components = useMemo(
+    () => ({
+      p: ({ children }: { children?: React.ReactNode }) => (
+        <p className="my-1.5 first:mt-0 last:mb-0">{children}</p>
+      ),
+      a: ({
+        href,
+        children,
+      }: {
+        href?: string;
+        children?: React.ReactNode;
+      }) => (
+        <a
+          href={href}
+          target={href?.startsWith("http") ? "_blank" : undefined}
+          rel={href?.startsWith("http") ? "noopener noreferrer" : undefined}
+          className="text-primary underline-offset-2 hover:underline"
+        >
+          {children}
+        </a>
+      ),
+      strong: ({ children }: { children?: React.ReactNode }) => (
+        <strong className="font-semibold text-foreground">{children}</strong>
+      ),
+      em: ({ children }: { children?: React.ReactNode }) => (
+        <em className="italic">{children}</em>
+      ),
+      ul: ({ children }: { children?: React.ReactNode }) => (
+        <ul className="my-1.5 ml-4 list-disc space-y-1 first:mt-0 last:mb-0">
+          {children}
+        </ul>
+      ),
+      ol: ({ children }: { children?: React.ReactNode }) => (
+        <ol className="my-1.5 ml-4 list-decimal space-y-1 first:mt-0 last:mb-0">
+          {children}
+        </ol>
+      ),
+      li: ({ children }: { children?: React.ReactNode }) => (
+        <li className="leading-relaxed">{children}</li>
+      ),
+      code: ({ children }: { children?: React.ReactNode }) => (
+        <code className="rounded bg-muted px-1 py-0.5 font-mono text-[0.8em]">
+          {children}
+        </code>
+      ),
+      pre: ({ children }: { children?: React.ReactNode }) => (
+        <pre className="my-1.5 overflow-x-auto rounded-lg border border-border/40 bg-muted/60 p-2 font-mono text-xs first:mt-0 last:mb-0">
+          {children}
+        </pre>
+      ),
+      h1: ({ children }: { children?: React.ReactNode }) => (
+        <h1 className="mt-2 mb-1 text-base font-bold first:mt-0">{children}</h1>
+      ),
+      h2: ({ children }: { children?: React.ReactNode }) => (
+        <h2 className="mt-2 mb-1 text-sm font-bold first:mt-0">{children}</h2>
+      ),
+      h3: ({ children }: { children?: React.ReactNode }) => (
+        <h3 className="mt-1.5 mb-0.5 text-sm font-semibold first:mt-0">
+          {children}
+        </h3>
+      ),
+      blockquote: ({ children }: { children?: React.ReactNode }) => (
+        <blockquote className="my-1.5 border-l-2 border-primary/40 pl-2 italic first:mt-0 last:mb-0">
+          {children}
+        </blockquote>
+      ),
+    }),
+    [],
+  );
+
+  return (
+    <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+      {content}
+    </ReactMarkdown>
+  );
+}
+
+export const ChatMarkdown = memo(MarkdownImpl);

--- a/src/components/ai/chat-message.tsx
+++ b/src/components/ai/chat-message.tsx
@@ -18,6 +18,15 @@ const SURFACE_TOOL_TYPES = new Set([
   "tool-surface_blog_card",
 ]);
 
+function isSurfaceToolPart(part: unknown): part is {
+  type: string;
+  input?: unknown;
+  output?: unknown;
+  state?: string;
+} {
+  return isToolPart(part) && SURFACE_TOOL_TYPES.has(part.type);
+}
+
 function isTextPart(
   part: unknown,
 ): part is { type: "text"; text: string; state?: string } {
@@ -34,13 +43,119 @@ function isToolPart(
   return typeof p.type === "string" && p.type.startsWith("tool-");
 }
 
+function isReasoningPart(
+  part: unknown,
+): part is { type: "reasoning"; text: string; state?: string } {
+  if (typeof part !== "object" || part === null) return false;
+  const p = part as { type?: unknown; text?: unknown };
+  return p.type === "reasoning" && typeof p.text === "string";
+}
+
+function getToolStatusLabel(toolType: string): string {
+  switch (toolType) {
+    case "tool_get_team_members":
+      return "Getting team members info";
+    case "tool_get_team_member":
+      return "Fetching member details";
+    case "tool_get_products":
+      return "Checking products";
+    case "tool_get_product":
+      return "Fetching product details";
+    case "tool_get_blog_posts":
+      return "Searching blog posts";
+    case "tool_get_blog_post":
+      return "Reading blog post";
+    case "tool_get_community_info":
+      return "Checking community info";
+    case "tool_surface_team_card":
+      return "Preparing team card";
+    case "tool_surface_product_card":
+      return "Preparing product card";
+    case "tool_surface_blog_card":
+      return "Preparing blog card";
+    default:
+      return "Working on answer";
+  }
+}
+
+function getAssistantStatusLabel(message: UIMessage): string {
+  const parts = message.parts ?? [];
+  const lastStepStartIndex = parts.reduce(
+    (lastIndex, part, index) =>
+      part.type === "step-start" ? index : lastIndex,
+    -1,
+  );
+  const currentParts =
+    lastStepStartIndex >= 0 ? parts.slice(lastStepStartIndex + 1) : parts;
+
+  const activeTool = [...currentParts]
+    .reverse()
+    .find(
+      (part) =>
+        isToolPart(part) &&
+        part.state !== "output-available" &&
+        part.state !== "output-error" &&
+        part.state !== "output-denied",
+    );
+  if (activeTool) {
+    return getToolStatusLabel(activeTool.type);
+  }
+
+  const hasStreamingText = currentParts.some(
+    (part) => isTextPart(part) && part.state === "streaming",
+  );
+  if (hasStreamingText) {
+    return "Writing answer";
+  }
+
+  const hasReasoning = currentParts.some(
+    (part) => isReasoningPart(part) && part.state === "streaming",
+  );
+  if (hasReasoning) {
+    return "Thinking";
+  }
+
+  const hasCompletedTool = currentParts.some(
+    (part) =>
+      isToolPart(part) &&
+      (part.state === "output-available" || part.state === "output-error"),
+  );
+  if (hasCompletedTool) {
+    return "Organizing information";
+  }
+
+  const hasVisibleText = currentParts.some(
+    (part) => isTextPart(part) && part.text.trim().length > 0,
+  );
+  if (hasVisibleText) {
+    return "Writing answer";
+  }
+
+  return "Thinking";
+}
+
 export function ChatMessageBubble({
   message,
   isStreaming,
 }: ChatMessageBubbleProps) {
   const isUser = message.role === "user";
+  const messageWithContent = message as unknown as { content?: unknown };
+  const content =
+    typeof messageWithContent.content === "string"
+      ? messageWithContent.content
+      : "";
+  const rawParts =
+    message.parts && message.parts.length > 0
+      ? message.parts
+      : content
+        ? [{ type: "text", text: content }]
+        : [];
 
-  const sortedParts = [...(message.parts ?? [])].sort((a, b) => {
+  const displayParts = rawParts.filter(
+    (part) => isTextPart(part) || isSurfaceToolPart(part),
+  );
+
+  const sortedParts = [...displayParts].sort((a, b) => {
     const orderA = isTextPart(a) ? 0 : 1;
     const orderB = isTextPart(b) ? 0 : 1;
     return orderA - orderB;
@@ -51,8 +166,6 @@ export function ChatMessageBubble({
       isTextPart(p) ||
       SURFACE_TOOL_TYPES.has((p as { type?: string }).type ?? ""),
   );
-
-  if (!hasContent) return null;
 
   const dedupedParts = sortedParts.filter((part, index) => {
     if (!isToolPart(part)) return true;
@@ -69,30 +182,25 @@ export function ChatMessageBubble({
     );
   });
 
-  const hasTextContent = dedupedParts.some(
-    (p) => isTextPart(p) && p.text.trim().length > 0,
-  );
-
   const textParts = dedupedParts.filter(
     (p): p is { type: "text"; text: string } =>
       isTextPart(p) && p.text.trim().length > 0,
   );
 
-  const surfaceCards = dedupedParts.filter((p) => {
-    if (!isToolPart(p)) return false;
-    return SURFACE_TOOL_TYPES.has(p.type);
-  });
+  const surfaceCards = dedupedParts.filter(isSurfaceToolPart);
+  const statusLabel =
+    isStreaming && !isUser ? getAssistantStatusLabel(message) : null;
 
-  const runningTools = dedupedParts.filter((p) => {
-    if (!isToolPart(p)) return false;
-    if (SURFACE_TOOL_TYPES.has(p.type)) return false;
-    if (p.state === "output-available") return false;
-    return true;
-  });
-
-  const thinking = isStreaming && !hasTextContent && runningTools.length === 0;
-
-  const working = isStreaming && !hasTextContent && runningTools.length > 0;
+  if (!hasContent) {
+    if (statusLabel) {
+      return (
+        <div className="flex w-full justify-start" data-role={message.role}>
+          <AssistantStatusPill label={statusLabel} />
+        </div>
+      );
+    }
+    return null;
+  }
 
   return (
     <div
@@ -101,13 +209,13 @@ export function ChatMessageBubble({
     >
       {isUser ? (
         <div className="w-fit max-w-[75%] space-y-1 rounded-3xl bg-primary px-3.5 py-2.5 text-primary-foreground shadow-sm">
-          {dedupedParts.map((part, idx) => {
+          {dedupedParts.map((part) => {
             if (isTextPart(part)) {
               const text = part.text;
               if (!text) return null;
               return (
                 <div
-                  key={`text-${idx}`}
+                  key={`user-text-${text}`}
                   className="whitespace-pre-wrap text-sm leading-relaxed"
                 >
                   {text}
@@ -119,124 +227,92 @@ export function ChatMessageBubble({
         </div>
       ) : (
         <div className="max-w-[88%] space-y-1.5">
-          {thinking && (
-            <div className="flex items-center gap-1.5 rounded-full border border-border/40 bg-muted/40 px-3 py-2">
-              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-primary/60 [animation-delay:-0.6s]" />
-              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-primary/60 [animation-delay:-0.3s]" />
-              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-primary/60" />
-              <span className="text-[11px] text-muted-foreground">
-                Thinking
-              </span>
-            </div>
-          )}
+          {statusLabel && <AssistantStatusPill label={statusLabel} />}
 
-          {working &&
-            runningTools.map((part, idx) => (
-              <div
-                key={`tool-${idx}`}
-                className="flex items-center gap-1.5 rounded-full border border-border/40 bg-muted/40 px-3 py-1 text-[11px] text-muted-foreground"
-              >
-                <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-primary" />
-                <span>
-                  Looking up{" "}
-                  {part.type.replace(/^tool-/, "").replace(/_/g, " ")}
-                  ...
-                </span>
-              </div>
-            ))}
-
-          {textParts.map((part, idx) => (
-            <ChatText key={`text-${idx}`} text={part.text} />
+          {textParts.map((part) => (
+            <ChatText key={`assistant-text-${part.text}`} text={part.text} />
           ))}
 
-          {surfaceCards.map((part, idx) => {
-            const type = part.type;
+          {surfaceCards.map((part) => {
+            const tp = part as {
+              type: string;
+              input?: unknown;
+              output?: unknown;
+            };
+            const type = tp.type;
+            const input =
+              tp.input && typeof tp.input === "object"
+                ? (tp.input as Record<string, unknown>)
+                : {};
+            const slug = typeof input.slug === "string" ? input.slug : "";
+            if (!slug) return null;
+            const reason = typeof input.reason === "string" ? input.reason : "";
+            const out =
+              tp.output && typeof tp.output === "object"
+                ? (tp.output as Record<string, unknown>)
+                : {};
             if (type === "tool-surface_team_card") {
-              const input = (part.input ?? {}) as {
-                slug?: string;
-                reason?: string;
-              };
-              const output = part.output as
-                | {
-                    slug?: string;
-                    reason?: string;
-                    name?: string;
-                    role?: string;
-                    avatar?: string;
-                    profileUrl?: string;
-                    isHireable?: boolean;
-                    tagline?: string;
-                  }
-                | undefined;
-              if (!input.slug) return null;
               return (
                 <ChatTeamCard
-                  key={`team-${input.slug}-${idx}`}
-                  slug={input.slug}
-                  reason={input.reason ?? ""}
-                  name={output?.name}
-                  role={output?.role}
-                  avatar={output?.avatar}
-                  profileUrl={output?.profileUrl}
-                  isHireable={output?.isHireable}
+                  key={`team-${slug}`}
+                  slug={slug}
+                  reason={reason}
+                  name={typeof out.name === "string" ? out.name : undefined}
+                  role={typeof out.role === "string" ? out.role : undefined}
+                  avatar={
+                    typeof out.avatar === "string" ? out.avatar : undefined
+                  }
+                  profileUrl={
+                    typeof out.profileUrl === "string"
+                      ? out.profileUrl
+                      : undefined
+                  }
+                  isHireable={
+                    typeof out.isHireable === "boolean"
+                      ? out.isHireable
+                      : undefined
+                  }
                 />
               );
             }
             if (type === "tool-surface_product_card") {
-              const input = (part.input ?? {}) as {
-                slug?: string;
-                reason?: string;
-              };
-              const output = part.output as
-                | {
-                    slug?: string;
-                    reason?: string;
-                    name?: string;
-                    tagline?: string;
-                    pageUrl?: string;
-                    image?: string;
-                  }
-                | undefined;
-              if (!input.slug) return null;
               return (
                 <ChatProductCard
-                  key={`product-${input.slug}-${idx}`}
-                  slug={input.slug}
-                  reason={input.reason ?? ""}
-                  name={output?.name}
-                  tagline={output?.tagline}
-                  pageUrl={output?.pageUrl}
-                  image={output?.image}
+                  key={`product-${slug}`}
+                  slug={slug}
+                  reason={reason}
+                  name={typeof out.name === "string" ? out.name : undefined}
+                  tagline={
+                    typeof out.tagline === "string" ? out.tagline : undefined
+                  }
+                  pageUrl={
+                    typeof out.pageUrl === "string" ? out.pageUrl : undefined
+                  }
+                  image={typeof out.image === "string" ? out.image : undefined}
                 />
               );
             }
             if (type === "tool-surface_blog_card") {
-              const input = (part.input ?? {}) as {
-                slug?: string;
-                reason?: string;
-              };
-              const output = part.output as
-                | {
-                    slug?: string;
-                    reason?: string;
-                    title?: string;
-                    excerpt?: string;
-                    authorName?: string;
-                    readingTime?: number;
-                    url?: string;
-                  }
-                | undefined;
-              if (!input.slug) return null;
               return (
                 <ChatBlogCard
-                  key={`blog-${input.slug}-${idx}`}
-                  slug={input.slug}
-                  reason={input.reason ?? ""}
-                  title={output?.title}
-                  excerpt={output?.excerpt}
-                  authorName={output?.authorName}
-                  readingTime={output?.readingTime}
-                  url={output?.url}
+                  key={`blog-${slug}`}
+                  slug={slug}
+                  reason={reason}
+                  title={typeof out.title === "string" ? out.title : undefined}
+                  excerpt={
+                    typeof out.excerpt === "string" ? out.excerpt : undefined
+                  }
+                  authorName={
+                    typeof out.authorName === "string"
+                      ? out.authorName
+                      : undefined
+                  }
+                  readingTime={
+                    typeof out.readingTime === "number"
+                      ? out.readingTime
+                      : undefined
+                  }
+                  url={typeof out.url === "string" ? out.url : undefined}
                 />
               );
             }
@@ -244,6 +320,17 @@ export function ChatMessageBubble({
           })}
         </div>
       )}
+    </div>
+  );
+}
+
+function AssistantStatusPill({ label }: { label: string }) {
+  return (
+    <div className="flex w-fit items-center gap-1.5 rounded-full border border-border/40 bg-muted/40 px-3 py-2">
+      <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-primary/60 [animation-delay:-0.6s]" />
+      <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-primary/60 [animation-delay:-0.3s]" />
+      <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-primary/60" />
+      <span className="text-[11px] text-muted-foreground">{label}</span>
     </div>
   );
 }
@@ -261,6 +348,9 @@ export function ChatMessageList({
 }: ChatMessageListProps) {
   if (messages.length === 0) return null;
 
+  const shouldShowPendingAssistant =
+    isStreaming && messages[messages.length - 1]?.role === "user";
+
   return (
     <div className="flex flex-col gap-3">
       {resumeMessage && (
@@ -275,6 +365,11 @@ export function ChatMessageList({
           isStreaming={isStreaming && idx === messages.length - 1}
         />
       ))}
+      {shouldShowPendingAssistant && (
+        <div className="flex w-full justify-start" data-role="assistant">
+          <AssistantStatusPill label="Thinking" />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/ai/chat-message.tsx
+++ b/src/components/ai/chat-message.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import type { UIMessage } from "@ai-sdk/react";
+import { cn } from "@/lib/utils";
+import { ChatBlogCard } from "./chat-blog-card";
+import { ChatProductCard } from "./chat-product-card";
+import { ChatTeamCard } from "./chat-team-card";
+import { ChatText } from "./chat-text";
+
+interface ChatMessageBubbleProps {
+  message: UIMessage;
+  isStreaming?: boolean;
+}
+
+const SURFACE_TOOL_TYPES = new Set([
+  "tool-surface_team_card",
+  "tool-surface_product_card",
+  "tool-surface_blog_card",
+]);
+
+function isTextPart(
+  part: unknown,
+): part is { type: "text"; text: string; state?: string } {
+  if (typeof part !== "object" || part === null) return false;
+  const p = part as { type?: unknown; text?: unknown };
+  return p.type === "text" && typeof p.text === "string";
+}
+
+function isToolPart(
+  part: unknown,
+): part is { type: string; input?: unknown; output?: unknown; state?: string } {
+  if (typeof part !== "object" || part === null) return false;
+  const p = part as { type?: unknown };
+  return typeof p.type === "string" && p.type.startsWith("tool-");
+}
+
+export function ChatMessageBubble({
+  message,
+  isStreaming,
+}: ChatMessageBubbleProps) {
+  const isUser = message.role === "user";
+
+  const sortedParts = [...(message.parts ?? [])].sort((a, b) => {
+    const orderA = isTextPart(a) ? 0 : 1;
+    const orderB = isTextPart(b) ? 0 : 1;
+    return orderA - orderB;
+  });
+
+  const hasContent = sortedParts.some(
+    (p) =>
+      isTextPart(p) ||
+      SURFACE_TOOL_TYPES.has((p as { type?: string }).type ?? ""),
+  );
+
+  if (!hasContent) return null;
+
+  const dedupedParts = sortedParts.filter((part, index) => {
+    if (!isToolPart(part)) return true;
+    const slug = (part.input as { slug?: string } | undefined)?.slug;
+    if (!slug) return true;
+    const _key = `${part.type}-${slug}`;
+    return (
+      sortedParts.findLastIndex(
+        (p) =>
+          isToolPart(p) &&
+          p.type === part.type &&
+          (p.input as { slug?: string } | undefined)?.slug === slug,
+      ) === index
+    );
+  });
+
+  const hasTextContent = dedupedParts.some(
+    (p) => isTextPart(p) && p.text.trim().length > 0,
+  );
+
+  const textParts = dedupedParts.filter(
+    (p): p is { type: "text"; text: string } =>
+      isTextPart(p) && p.text.trim().length > 0,
+  );
+
+  const surfaceCards = dedupedParts.filter((p) => {
+    if (!isToolPart(p)) return false;
+    return SURFACE_TOOL_TYPES.has(p.type);
+  });
+
+  const runningTools = dedupedParts.filter((p) => {
+    if (!isToolPart(p)) return false;
+    if (SURFACE_TOOL_TYPES.has(p.type)) return false;
+    if (p.state === "output-available") return false;
+    return true;
+  });
+
+  const thinking = isStreaming && !hasTextContent && runningTools.length === 0;
+
+  const working = isStreaming && !hasTextContent && runningTools.length > 0;
+
+  return (
+    <div
+      className={cn("flex w-full", isUser ? "justify-end" : "justify-start")}
+      data-role={message.role}
+    >
+      {isUser ? (
+        <div className="w-fit max-w-[75%] space-y-1 rounded-3xl bg-primary px-3.5 py-2.5 text-primary-foreground shadow-sm">
+          {dedupedParts.map((part, idx) => {
+            if (isTextPart(part)) {
+              const text = part.text;
+              if (!text) return null;
+              return (
+                <div
+                  key={`text-${idx}`}
+                  className="whitespace-pre-wrap text-sm leading-relaxed"
+                >
+                  {text}
+                </div>
+              );
+            }
+            return null;
+          })}
+        </div>
+      ) : (
+        <div className="max-w-[88%] space-y-1.5">
+          {thinking && (
+            <div className="flex items-center gap-1.5 rounded-full border border-border/40 bg-muted/40 px-3 py-2">
+              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-primary/60 [animation-delay:-0.6s]" />
+              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-primary/60 [animation-delay:-0.3s]" />
+              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-primary/60" />
+              <span className="text-[11px] text-muted-foreground">
+                Thinking
+              </span>
+            </div>
+          )}
+
+          {working &&
+            runningTools.map((part, idx) => (
+              <div
+                key={`tool-${idx}`}
+                className="flex items-center gap-1.5 rounded-full border border-border/40 bg-muted/40 px-3 py-1 text-[11px] text-muted-foreground"
+              >
+                <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-primary" />
+                <span>
+                  Looking up{" "}
+                  {part.type.replace(/^tool-/, "").replace(/_/g, " ")}
+                  ...
+                </span>
+              </div>
+            ))}
+
+          {textParts.map((part, idx) => (
+            <ChatText key={`text-${idx}`} text={part.text} />
+          ))}
+
+          {surfaceCards.map((part, idx) => {
+            const type = part.type;
+            if (type === "tool-surface_team_card") {
+              const input = (part.input ?? {}) as {
+                slug?: string;
+                reason?: string;
+              };
+              const output = part.output as
+                | {
+                    slug?: string;
+                    reason?: string;
+                    name?: string;
+                    role?: string;
+                    avatar?: string;
+                    profileUrl?: string;
+                    isHireable?: boolean;
+                    tagline?: string;
+                  }
+                | undefined;
+              if (!input.slug) return null;
+              return (
+                <ChatTeamCard
+                  key={`team-${input.slug}-${idx}`}
+                  slug={input.slug}
+                  reason={input.reason ?? ""}
+                  name={output?.name}
+                  role={output?.role}
+                  avatar={output?.avatar}
+                  profileUrl={output?.profileUrl}
+                  isHireable={output?.isHireable}
+                />
+              );
+            }
+            if (type === "tool-surface_product_card") {
+              const input = (part.input ?? {}) as {
+                slug?: string;
+                reason?: string;
+              };
+              const output = part.output as
+                | {
+                    slug?: string;
+                    reason?: string;
+                    name?: string;
+                    tagline?: string;
+                    pageUrl?: string;
+                    image?: string;
+                  }
+                | undefined;
+              if (!input.slug) return null;
+              return (
+                <ChatProductCard
+                  key={`product-${input.slug}-${idx}`}
+                  slug={input.slug}
+                  reason={input.reason ?? ""}
+                  name={output?.name}
+                  tagline={output?.tagline}
+                  pageUrl={output?.pageUrl}
+                  image={output?.image}
+                />
+              );
+            }
+            if (type === "tool-surface_blog_card") {
+              const input = (part.input ?? {}) as {
+                slug?: string;
+                reason?: string;
+              };
+              const output = part.output as
+                | {
+                    slug?: string;
+                    reason?: string;
+                    title?: string;
+                    excerpt?: string;
+                    authorName?: string;
+                    readingTime?: number;
+                    url?: string;
+                  }
+                | undefined;
+              if (!input.slug) return null;
+              return (
+                <ChatBlogCard
+                  key={`blog-${input.slug}-${idx}`}
+                  slug={input.slug}
+                  reason={input.reason ?? ""}
+                  title={output?.title}
+                  excerpt={output?.excerpt}
+                  authorName={output?.authorName}
+                  readingTime={output?.readingTime}
+                  url={output?.url}
+                />
+              );
+            }
+            return null;
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface ChatMessageListProps {
+  messages: UIMessage[];
+  resumeMessage?: string | null;
+  isStreaming?: boolean;
+}
+
+export function ChatMessageList({
+  messages,
+  resumeMessage,
+  isStreaming,
+}: ChatMessageListProps) {
+  if (messages.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-3">
+      {resumeMessage && (
+        <div className="mx-auto rounded-full border border-border/40 bg-muted/40 px-3 py-1 text-[11px] text-muted-foreground">
+          {resumeMessage}
+        </div>
+      )}
+      {messages.map((m, idx) => (
+        <ChatMessageBubble
+          key={m.id}
+          message={m}
+          isStreaming={isStreaming && idx === messages.length - 1}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/ai/chat-panel.tsx
+++ b/src/components/ai/chat-panel.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useReducedMotion } from "framer-motion";
+import { useEffect, useRef } from "react";
+import type { VisitorIntent } from "@/lib/ai/types";
+import { cn } from "@/lib/utils";
+import { ChatHeader } from "./chat-header";
+import { ChatInput } from "./chat-input";
+import { ChatMessageList } from "./chat-message";
+import { useChatContext } from "./chat-provider";
+import { ChatWelcome } from "./chat-welcome";
+
+interface ChatPanelProps {
+  variant?: "floating" | "fullscreen";
+  className?: string;
+}
+
+export function ChatPanel({
+  variant = "fullscreen",
+  className,
+}: ChatPanelProps) {
+  const reduced = useReducedMotion();
+  const {
+    messages,
+    status,
+    error,
+    clear,
+    resumeMessage,
+    setExplicitSeed,
+    sendMessage,
+    close,
+  } = useChatContext();
+
+  const isStreaming = status === "streaming" || status === "submitted";
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll on new message
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTo({
+      top: el.scrollHeight,
+      behavior: reduced ? "auto" : "smooth",
+    });
+  }, [messages, reduced]);
+
+  const handlePick = (text: string) => {
+    if (isStreaming) return;
+    sendMessage({ text });
+  };
+
+  const handlePickPersona = (intent: VisitorIntent, text: string) => {
+    setExplicitSeed(intent);
+    if (!isStreaming) sendMessage({ text });
+  };
+
+  const containerClasses = cn(
+    "relative flex h-full min-h-0 w-full flex-col overflow-hidden border border-border/60 bg-card shadow-[0_20px_50px_-10px_hsla(0,0%,0%,0.28)]",
+    variant === "floating" && "rounded-none sm:rounded-[32px]",
+    variant === "fullscreen" && "rounded-[32px] bg-card p-2",
+    className,
+  );
+
+  return (
+    <div className={containerClasses} data-lenis-prevent>
+      <div className="absolute inset-x-0 top-0 z-10 bg-gradient-to-b from-card via-card/95 to-transparent pb-8 pt-2 sm:pb-10">
+        <ChatHeader
+          variant={variant}
+          onClose={variant === "floating" ? close : undefined}
+          onClear={clear}
+          isStreaming={isStreaming}
+        />
+      </div>
+
+      <div
+        ref={scrollRef}
+        data-lenis-prevent
+        data-lenis-prevent-wheel
+        data-lenis-prevent-touch
+        onWheelCapture={(event) => event.stopPropagation()}
+        onTouchMoveCapture={(event) => event.stopPropagation()}
+        className={cn(
+          "min-h-0 flex-1 overflow-y-auto overscroll-contain px-3 pb-16 pt-20 sm:px-4 sm:pb-20 sm:pt-24",
+          variant === "fullscreen" && "rounded-[24px] bg-background/70",
+          "[&::-webkit-scrollbar]:w-[3px] [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border/50 [&::-webkit-scrollbar-thumb]:hover:bg-border/80",
+        )}
+        role="log"
+        aria-live="polite"
+        aria-label="Chat messages"
+      >
+        {messages.length === 0 ? (
+          <ChatWelcome onPick={handlePick} onPickPersona={handlePickPersona} />
+        ) : (
+          <div className="space-y-3">
+            <ChatMessageList
+              messages={messages}
+              resumeMessage={resumeMessage}
+              isStreaming={isStreaming}
+            />
+            {error && (
+              <div className="rounded-2xl border border-destructive/40 bg-destructive/10 p-3 text-xs text-destructive">
+                Something went wrong. Try again or refresh the page.
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-card via-card/95 to-transparent pt-8">
+        <ChatInput floating />
+      </div>
+    </div>
+  );
+}

--- a/src/components/ai/chat-panel.tsx
+++ b/src/components/ai/chat-panel.tsx
@@ -80,7 +80,7 @@ export function ChatPanel({
         onWheelCapture={(event) => event.stopPropagation()}
         onTouchMoveCapture={(event) => event.stopPropagation()}
         className={cn(
-          "min-h-0 flex-1 overflow-y-auto overscroll-contain px-3 pb-16 pt-20 sm:px-4 sm:pb-20 sm:pt-24",
+          "min-h-0 flex-1 overflow-y-auto overscroll-contain px-3 pb-28 pt-20 sm:px-4 sm:pb-32 sm:pt-24",
           variant === "fullscreen" && "rounded-[24px] bg-background/70",
           "[&::-webkit-scrollbar]:w-[3px] [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border/50 [&::-webkit-scrollbar-thumb]:hover:bg-border/80",
         )}

--- a/src/components/ai/chat-panel.tsx
+++ b/src/components/ai/chat-panel.tsx
@@ -55,9 +55,9 @@ export function ChatPanel({
   };
 
   const containerClasses = cn(
-    "relative flex h-full min-h-0 w-full flex-col overflow-hidden border border-border/60 bg-card shadow-[0_20px_50px_-10px_hsla(0,0%,0%,0.28)]",
-    variant === "floating" && "rounded-none sm:rounded-[32px]",
-    variant === "fullscreen" && "rounded-[32px] bg-card p-2",
+    "relative flex h-full min-h-0 w-full flex-col overflow-hidden bg-background",
+    variant === "floating" && "rounded-none shadow-2xl bg-card",
+    variant === "fullscreen" && "rounded-none",
     className,
   );
 
@@ -81,7 +81,7 @@ export function ChatPanel({
         onTouchMoveCapture={(event) => event.stopPropagation()}
         className={cn(
           "min-h-0 flex-1 overflow-y-auto overscroll-contain px-3 pb-28 pt-20 sm:px-4 sm:pb-32 sm:pt-24",
-          variant === "fullscreen" && "rounded-[24px] bg-background/70",
+          variant === "fullscreen" && "rounded-none",
           "[&::-webkit-scrollbar]:w-[3px] [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border/50 [&::-webkit-scrollbar-thumb]:hover:bg-border/80",
         )}
         role="log"
@@ -89,9 +89,14 @@ export function ChatPanel({
         aria-label="Chat messages"
       >
         {messages.length === 0 ? (
-          <ChatWelcome onPick={handlePick} onPickPersona={handlePickPersona} />
+          <div className="mx-auto max-w-4xl">
+            <ChatWelcome
+              onPick={handlePick}
+              onPickPersona={handlePickPersona}
+            />
+          </div>
         ) : (
-          <div className="space-y-3">
+          <div className="mx-auto max-w-4xl space-y-3">
             <ChatMessageList
               messages={messages}
               resumeMessage={resumeMessage}

--- a/src/components/ai/chat-product-card.tsx
+++ b/src/components/ai/chat-product-card.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { ArrowSquareOut } from "@phosphor-icons/react";
+import Image from "next/image";
+import Link from "next/link";
+
+interface ChatProductCardProps {
+  slug: string;
+  reason: string;
+  name?: string;
+  tagline?: string;
+  pageUrl?: string;
+  image?: string;
+}
+
+export function ChatProductCard({
+  slug,
+  reason,
+  name,
+  tagline,
+  pageUrl,
+  image,
+}: ChatProductCardProps) {
+  const url = pageUrl ?? `/products/${slug}`;
+  const displayName = name ?? slug;
+  const displayTagline = tagline ?? "Volvox product";
+
+  return (
+    <div className="group relative my-2 overflow-hidden rounded-2xl border border-border/50 bg-gradient-to-br from-card/80 to-card/40 p-3 backdrop-blur-sm">
+      <div className="flex items-start gap-3">
+        <div className="relative h-12 w-12 shrink-0 overflow-hidden rounded-xl border border-border/40 bg-muted">
+          {image ? (
+            <Image
+              src={image}
+              alt={displayName}
+              fill
+              sizes="48px"
+              className="object-cover"
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center text-xs font-semibold text-muted-foreground">
+              {displayName.slice(0, 2).toUpperCase()}
+            </div>
+          )}
+        </div>
+        <div className="min-w-0 flex-1">
+          <h4 className="truncate text-sm font-semibold text-foreground">
+            {displayName}
+          </h4>
+          <p className="line-clamp-1 text-xs text-muted-foreground">
+            {displayTagline}
+          </p>
+          <p className="mt-1.5 line-clamp-2 text-xs leading-relaxed text-foreground/70">
+            {reason}
+          </p>
+        </div>
+      </div>
+      <Link
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="mt-3 inline-flex w-full items-center justify-center gap-1.5 rounded-full bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+      >
+        View product
+        <ArrowSquareOut className="h-3 w-3" weight="bold" />
+      </Link>
+    </div>
+  );
+}

--- a/src/components/ai/chat-provider.tsx
+++ b/src/components/ai/chat-provider.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { type UIMessage, useChat } from "@ai-sdk/react";
+import { DefaultChatTransport } from "ai";
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { clearChat, loadChat, saveChat } from "@/lib/ai/chat-store";
+import type { VisitorIntent } from "@/lib/ai/types";
+
+interface ChatContextValue {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+  messages: UIMessage[];
+  sendMessage: (msg: { text: string }) => Promise<void>;
+  status: "submitted" | "streaming" | "ready" | "error";
+  error: Error | undefined;
+  stop: () => void;
+  reload: () => void;
+  clear: () => void;
+  hasUnread: boolean;
+  markRead: () => void;
+  detectedIntent: VisitorIntent;
+  detectedConfidence: number;
+  rateLimitRemaining: number | null;
+  explicitSeed: VisitorIntent | null;
+  setExplicitSeed: (seed: VisitorIntent | null) => void;
+  storageLoaded: boolean;
+  resumeMessage: string | null;
+}
+
+const ChatContext = createContext<ChatContextValue | undefined>(undefined);
+
+export function ChatProvider({ children }: { children: ReactNode }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [hasUnread, setHasUnread] = useState(false);
+  const [explicitSeed, setExplicitSeed] = useState<VisitorIntent | null>(null);
+  const [storageLoaded, setStorageLoaded] = useState(false);
+  const [resumeMessage, setResumeMessage] = useState<string | null>(null);
+  const [detectedIntent, setDetectedIntent] =
+    useState<VisitorIntent>("professional");
+  const [detectedConfidence, setDetectedConfidence] = useState(0);
+  const [rateLimitRemaining, setRateLimitRemaining] = useState<number | null>(
+    null,
+  );
+
+  const wasStreamingRef = useRef(false);
+
+  const transport = useMemo(
+    () =>
+      new DefaultChatTransport({
+        api: "/api/chat",
+        prepareSendMessagesRequest: ({ messages }) => ({
+          body: {
+            messages,
+            intentSeed: explicitSeed,
+          },
+        }),
+      }),
+    [explicitSeed],
+  );
+
+  const {
+    messages,
+    sendMessage,
+    status,
+    error,
+    stop,
+    regenerate,
+    setMessages,
+  } = useChat({
+    id: "volvox-assistant",
+    transport,
+    onData: (part) => {
+      if (
+        typeof part === "object" &&
+        part !== null &&
+        "type" in part &&
+        (part as { type: string }).type === "data-chat-meta"
+      ) {
+        const data = (part as { data?: unknown }).data as
+          | {
+              intent?: VisitorIntent;
+              confidence?: number;
+              rateLimitRemaining?: number;
+            }
+          | undefined;
+        if (data?.intent) {
+          setDetectedIntent(data.intent);
+          setDetectedConfidence(data.confidence ?? 0);
+        }
+        if (typeof data?.rateLimitRemaining === "number") {
+          setRateLimitRemaining(data.rateLimitRemaining);
+        }
+      }
+    },
+    onError: (err) => {
+      console.error("[Volvox Assistant] chat error:", err);
+    },
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = loadChat();
+    if (stored && stored.messages.length > 0) {
+      setMessages(stored.messages as unknown as UIMessage[]);
+      setExplicitSeed(stored.intent);
+      if (stored.intent) setDetectedIntent(stored.intent);
+      const daysLeft = Math.max(
+        0,
+        Math.round((stored.expiresAt - Date.now()) / (24 * 60 * 60 * 1000)),
+      );
+      setResumeMessage(
+        daysLeft > 0
+          ? `Resuming your conversation from ${14 - daysLeft} day${14 - daysLeft === 1 ? "" : "s"} ago.`
+          : null,
+      );
+    }
+    setStorageLoaded(true);
+  }, [setMessages]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!storageLoaded) return;
+    if (messages.length === 0) return;
+    saveChat({ messages: messages as unknown[], intent: explicitSeed });
+  }, [messages, explicitSeed, storageLoaded]);
+
+  useEffect(() => {
+    if (isOpen && hasUnread) {
+      setHasUnread(false);
+    }
+  }, [isOpen, hasUnread]);
+
+  useEffect(() => {
+    if (status === "streaming" || status === "submitted") {
+      wasStreamingRef.current = true;
+    } else if (status === "ready" && wasStreamingRef.current) {
+      wasStreamingRef.current = false;
+      if (!isOpen) {
+        setHasUnread(true);
+      }
+    }
+  }, [status, isOpen]);
+
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+  const toggle = useCallback(() => setIsOpen((p) => !p), []);
+
+  const markRead = useCallback(() => setHasUnread(false), []);
+
+  const clear = useCallback(() => {
+    setMessages([]);
+    setExplicitSeed(null);
+    setDetectedIntent("professional");
+    setDetectedConfidence(0);
+    setResumeMessage(null);
+    clearChat();
+  }, [setMessages]);
+
+  const value = useMemo<ChatContextValue>(
+    () => ({
+      isOpen,
+      open,
+      close,
+      toggle,
+      messages,
+      sendMessage: async (msg: { text: string }) => {
+        await sendMessage(msg);
+      },
+      status,
+      error,
+      stop,
+      reload: () => {
+        void regenerate();
+      },
+      clear,
+      hasUnread,
+      markRead,
+      detectedIntent,
+      detectedConfidence,
+      rateLimitRemaining,
+      explicitSeed,
+      setExplicitSeed,
+      storageLoaded,
+      resumeMessage,
+    }),
+    [
+      isOpen,
+      open,
+      close,
+      toggle,
+      messages,
+      sendMessage,
+      status,
+      error,
+      stop,
+      regenerate,
+      clear,
+      hasUnread,
+      markRead,
+      detectedIntent,
+      detectedConfidence,
+      rateLimitRemaining,
+      explicitSeed,
+      storageLoaded,
+      resumeMessage,
+    ],
+  );
+
+  return <ChatContext.Provider value={value}>{children}</ChatContext.Provider>;
+}
+
+export function useChatContext(): ChatContextValue {
+  const ctx = useContext(ChatContext);
+  if (!ctx)
+    throw new Error("useChatContext must be used within a ChatProvider");
+  return ctx;
+}

--- a/src/components/ai/chat-provider.tsx
+++ b/src/components/ai/chat-provider.tsx
@@ -14,6 +14,7 @@ import {
 } from "react";
 import { clearChat, loadChat, saveChat } from "@/lib/ai/chat-store";
 import type { VisitorIntent } from "@/lib/ai/types";
+import { reportError } from "@/lib/logger";
 
 interface ChatContextValue {
   isOpen: boolean;

--- a/src/components/ai/chat-provider.tsx
+++ b/src/components/ai/chat-provider.tsx
@@ -104,7 +104,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
       }
     },
     onError: (err) => {
-      console.error("[Volvox Assistant] chat error:", err);
+      reportError("[Volvox Assistant] chat error", err);
     },
   });
 

--- a/src/components/ai/chat-team-card.tsx
+++ b/src/components/ai/chat-team-card.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { ArrowSquareOut, Briefcase } from "@phosphor-icons/react";
+import Image from "next/image";
+import Link from "next/link";
+
+interface ChatTeamCardProps {
+  slug: string;
+  reason: string;
+  name?: string;
+  role?: string;
+  avatar?: string;
+  profileUrl?: string;
+  isHireable?: boolean;
+}
+
+export function ChatTeamCard({
+  slug,
+  reason,
+  name,
+  role,
+  avatar,
+  profileUrl,
+  isHireable,
+}: ChatTeamCardProps) {
+  const url = profileUrl ?? `/team/${slug}`;
+  const displayName = name ?? slug;
+  const displayRole = role ?? "Volvox team member";
+
+  return (
+    <div className="group relative my-2 overflow-hidden rounded-2xl border border-border/50 bg-gradient-to-br from-card/80 to-card/40 p-3 backdrop-blur-sm">
+      <div className="flex items-start gap-3">
+        <div className="relative h-12 w-12 shrink-0 overflow-hidden rounded-xl border border-border/40 bg-muted">
+          {avatar ? (
+            <Image
+              src={avatar}
+              alt={displayName}
+              fill
+              sizes="48px"
+              className="object-cover"
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center text-xs font-semibold text-muted-foreground">
+              {displayName.slice(0, 2).toUpperCase()}
+            </div>
+          )}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <h4 className="truncate text-sm font-semibold text-foreground">
+              {displayName}
+            </h4>
+            {isHireable && (
+              <span className="shrink-0 rounded-full bg-accent/15 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-accent">
+                Hireable
+              </span>
+            )}
+          </div>
+          <p className="truncate text-xs text-muted-foreground">
+            {displayRole}
+          </p>
+          <p className="mt-1.5 line-clamp-2 text-xs leading-relaxed text-foreground/70">
+            {reason}
+          </p>
+        </div>
+      </div>
+      <div className="mt-3 flex items-center gap-1.5">
+        <Link
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-full bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+        >
+          View profile
+          <ArrowSquareOut className="h-3 w-3" weight="bold" />
+        </Link>
+        {isHireable && (
+          <Link
+            href={`/team/${slug}#hire`}
+            className="inline-flex items-center justify-center gap-1.5 rounded-full border border-accent/40 bg-accent/10 px-3 py-1.5 text-xs font-semibold text-accent transition-colors hover:bg-accent/20"
+          >
+            <Briefcase className="h-3 w-3" weight="bold" />
+            Hire
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ai/chat-text.tsx
+++ b/src/components/ai/chat-text.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { ChatMarkdown } from "./chat-markdown";
+
+interface ChatTextProps {
+  text: string;
+}
+
+export function ChatText({ text }: ChatTextProps) {
+  return (
+    <div className="text-sm leading-relaxed text-foreground">
+      <ChatMarkdown content={text} />
+    </div>
+  );
+}

--- a/src/components/ai/chat-trigger.tsx
+++ b/src/components/ai/chat-trigger.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { ChatsCircle, Sparkle, X } from "@phosphor-icons/react";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+
+interface ChatTriggerProps {
+  isOpen: boolean;
+  onOpen: () => void;
+  onClose: () => void;
+  hasUnread?: boolean;
+}
+
+export function ChatTrigger({
+  isOpen,
+  onOpen,
+  onClose,
+  hasUnread = false,
+}: ChatTriggerProps) {
+  const reduced = useReducedMotion();
+  const [mounted, setMounted] = useState(false);
+  const [showHint, setShowHint] = useState(false);
+  const [hintDismissed, setHintDismissed] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    if (typeof window === "undefined") return;
+    try {
+      if (window.sessionStorage.getItem("volvox-chat-hint-dismissed") === "1") {
+        setHintDismissed(true);
+      }
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    if (!mounted || hintDismissed) return;
+    const t = setTimeout(() => setShowHint(true), 4500);
+    const auto = setTimeout(() => {
+      setShowHint(false);
+    }, 18000);
+    return () => {
+      clearTimeout(t);
+      clearTimeout(auto);
+    };
+  }, [mounted, hintDismissed]);
+
+  const dismissHint = () => {
+    setShowHint(false);
+    setHintDismissed(true);
+    try {
+      window.sessionStorage.setItem("volvox-chat-hint-dismissed", "1");
+    } catch {}
+  };
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 flex items-end gap-3 sm:bottom-6 sm:right-6">
+      <AnimatePresence>
+        {showHint && !isOpen && (
+          <motion.div
+            initial={reduced ? false : { opacity: 0, x: 8, scale: 0.95 }}
+            animate={{ opacity: 1, x: 0, scale: 1 }}
+            exit={{ opacity: 0, x: 8, scale: 0.95 }}
+            transition={{ duration: 0.2 }}
+          >
+            <div className="rounded-3xl bg-card p-3 shadow-xl">
+              <div className="flex items-start gap-2">
+                <Sparkle
+                  className="mt-0.5 h-4 w-4 shrink-0 text-primary"
+                  weight="fill"
+                />
+                <div className="flex-1 text-xs leading-relaxed text-foreground/80">
+                  Try asking about our products, team, or how to join the
+                  community.
+                </div>
+                <button
+                  type="button"
+                  onClick={dismissHint}
+                  className="shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:text-foreground"
+                  aria-label="Dismiss hint"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      <AnimatePresence>
+        {!isOpen && (
+          <motion.button
+            type="button"
+            onClick={onOpen}
+            initial={reduced ? false : { opacity: 0, scale: 0.8, y: 16 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.8, y: 16 }}
+            transition={{
+              delay: reduced ? 0 : 1.2,
+              type: "spring",
+              stiffness: 260,
+              damping: 22,
+            }}
+            whileHover={reduced ? undefined : { scale: 1.05 }}
+            whileTap={reduced ? undefined : { scale: 0.95 }}
+            aria-label="Open Volvox Assistant"
+            className={cn(
+              "group relative flex h-12 w-12 items-center justify-center rounded-full",
+              "bg-primary text-primary-foreground shadow-xl shadow-primary/30",
+              "ring-2 ring-primary/20 ring-offset-2 ring-offset-background",
+              "focus-visible:outline-none focus-visible:ring-4",
+            )}
+          >
+            <ChatsCircle className="h-5 w-5" weight="fill" />
+            {hasUnread && (
+              <span className="absolute right-0.5 top-0.5 h-2 w-2 rounded-full bg-accent ring-2 ring-background" />
+            )}
+            <span className="sr-only">Open Volvox Assistant</span>
+          </motion.button>
+        )}
+      </AnimatePresence>
+      {isOpen && (
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close Volvox Assistant"
+          className="flex h-12 w-12 items-center justify-center rounded-full border border-border/60 bg-card text-foreground shadow-xl transition-colors hover:bg-card/80 sm:hidden"
+        >
+          <X className="h-5 w-5" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/ai/chat-welcome.tsx
+++ b/src/components/ai/chat-welcome.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import {
+  GraduationCap,
+  HandWaving,
+  MagnifyingGlass,
+  Tag,
+  UsersThree,
+} from "@phosphor-icons/react";
+import type { VisitorIntent } from "@/lib/ai/types";
+
+const STARTER_SUGGESTIONS = [
+  {
+    icon: Tag,
+    text: "What products does Volvox build?",
+  },
+  {
+    icon: UsersThree,
+    text: "Who's on the Volvox team?",
+  },
+  {
+    icon: HandWaving,
+    text: "How do I join the community?",
+  },
+  {
+    icon: MagnifyingGlass,
+    text: "What is Volvox?",
+  },
+];
+
+const PERSONA_CHIPS: Array<{
+  intent: VisitorIntent;
+  icon: typeof GraduationCap;
+  label: string;
+  description: string;
+  prompt: string;
+}> = [
+  {
+    intent: "beginner",
+    icon: GraduationCap,
+    label: "I'm new to coding",
+    description: "Show me the on-ramp for beginners.",
+    prompt: "I'm new to coding. Where should I start?",
+  },
+  {
+    intent: "professional",
+    icon: Tag,
+    label: "I'm a developer",
+    description: "I want to collaborate or contribute.",
+    prompt: "I'm a developer. What can I work on or learn from at Volvox?",
+  },
+  {
+    intent: "hirer",
+    icon: UsersThree,
+    label: "I'm looking to hire",
+    description: "Show me the team and hireable members.",
+    prompt:
+      "I'm looking to hire. Who on the Volvox team is available, and what have they built?",
+  },
+];
+
+interface ChatWelcomeProps {
+  onPick: (text: string) => void;
+  onPickPersona: (intent: VisitorIntent, text: string) => void;
+}
+
+export function ChatWelcome({ onPick, onPickPersona }: ChatWelcomeProps) {
+  return (
+    <div className="flex min-h-full flex-col gap-6 px-1 py-2 sm:px-2 sm:py-3">
+      <div className="relative overflow-hidden rounded-[24px] bg-card p-5 sm:p-6">
+        <div
+          className="pointer-events-none absolute -top-24 left-1/2 h-56 w-56 -translate-x-1/2 rounded-full opacity-80 blur-3xl"
+          style={{
+            background:
+              "radial-gradient(circle, oklch(from var(--primary) l c h / 0.18), transparent 70%)",
+          }}
+        />
+        <div className="relative space-y-4">
+          <div className="flex h-12 w-12 items-center justify-center rounded-[18px] border border-primary/20 bg-primary/10 text-primary">
+            <HandWaving className="h-5 w-5" weight="fill" />
+          </div>
+          <div className="space-y-2">
+            <h3 className="max-w-[14ch] font-[family-name:var(--font-jetbrains-mono)] text-2xl font-extrabold leading-tight tracking-tight text-foreground">
+              Start with your angle.
+            </h3>
+            <p className="max-w-[42ch] text-sm leading-relaxed text-muted-foreground">
+              Pick a role or ask directly. Answers can include products, team
+              profiles, blog posts, and community next steps.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <p className="px-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          Who are you?
+        </p>
+        <div className="grid grid-cols-1 gap-2">
+          {PERSONA_CHIPS.map((chip) => (
+            <button
+              key={chip.intent}
+              type="button"
+              onClick={() => onPickPersona(chip.intent, chip.prompt)}
+              className="group flex items-center gap-3 rounded-[20px] border border-border/50 bg-card p-3 text-left transition-[border-color,background-color,transform] hover:border-primary/40 hover:bg-background/70 active:scale-[0.99]"
+            >
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[16px] border border-border/40 bg-background text-primary transition-colors group-hover:bg-primary/10">
+                <chip.icon className="h-4 w-4" weight="duotone" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-semibold text-foreground">
+                  {chip.label}
+                </p>
+                <p className="text-[11px] leading-relaxed text-muted-foreground">
+                  {chip.description}
+                </p>
+              </div>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <p className="px-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          Quick prompts
+        </p>
+        <div className="flex flex-col gap-1.5">
+          {STARTER_SUGGESTIONS.map((s) => (
+            <button
+              key={s.text}
+              type="button"
+              onClick={() => onPick(s.text)}
+              className="group flex items-center gap-2.5 rounded-full border border-border/40 bg-card px-3.5 py-2 text-left text-sm text-foreground/80 transition-[border-color,background-color] hover:border-primary/30 hover:bg-background/70"
+            >
+              <s.icon
+                className="h-3.5 w-3.5 shrink-0 text-muted-foreground"
+                weight="duotone"
+              />
+              <span className="truncate">{s.text}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ai/chat-welcome.tsx
+++ b/src/components/ai/chat-welcome.tsx
@@ -67,7 +67,7 @@ interface ChatWelcomeProps {
 export function ChatWelcome({ onPick, onPickPersona }: ChatWelcomeProps) {
   return (
     <div className="flex min-h-full flex-col gap-6 px-1 py-2 sm:px-2 sm:py-3">
-      <div className="relative overflow-hidden rounded-[24px] bg-card p-5 sm:p-6">
+      <div className="relative overflow-hidden rounded-[24px] bg-background/50 border border-border/40 p-5 sm:p-6">
         <div
           className="pointer-events-none absolute -top-24 left-1/2 h-56 w-56 -translate-x-1/2 rounded-full opacity-80 blur-3xl"
           style={{
@@ -101,7 +101,7 @@ export function ChatWelcome({ onPick, onPickPersona }: ChatWelcomeProps) {
               key={chip.intent}
               type="button"
               onClick={() => onPickPersona(chip.intent, chip.prompt)}
-              className="group flex items-center gap-3 rounded-[20px] border border-border/50 bg-card p-3 text-left transition-[border-color,background-color,transform] hover:border-primary/40 hover:bg-background/70 active:scale-[0.99]"
+              className="group flex items-center gap-3 rounded-[20px] border border-border/50 bg-background/50 p-3 text-left transition-[border-color,background-color,transform] hover:border-primary/40 hover:bg-background/80 active:scale-[0.99]"
             >
               <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[16px] border border-border/40 bg-background text-primary transition-colors group-hover:bg-primary/10">
                 <chip.icon className="h-4 w-4" weight="duotone" />
@@ -129,7 +129,7 @@ export function ChatWelcome({ onPick, onPickPersona }: ChatWelcomeProps) {
               key={s.text}
               type="button"
               onClick={() => onPick(s.text)}
-              className="group flex items-center gap-2.5 rounded-full border border-border/40 bg-card px-3.5 py-2 text-left text-sm text-foreground/80 transition-[border-color,background-color] hover:border-primary/30 hover:bg-background/70"
+              className="group flex items-center gap-2.5 rounded-full border border-border/40 bg-background/50 px-3.5 py-2 text-left text-sm text-foreground/80 transition-[border-color,background-color] hover:border-primary/30 hover:bg-background/80"
             >
               <s.icon
                 className="h-3.5 w-3.5 shrink-0 text-muted-foreground"

--- a/src/components/ai/volvox-assistant.tsx
+++ b/src/components/ai/volvox-assistant.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { usePathname } from "next/navigation";
+import { useEffect } from "react";
+import { cn } from "@/lib/utils";
+import { ChatPanel } from "./chat-panel";
+import { ChatProvider, useChatContext } from "./chat-provider";
+import { ChatTrigger } from "./chat-trigger";
+
+function AssistantInner() {
+  const { isOpen, open, close, hasUnread, markRead } = useChatContext();
+  const reduced = useReducedMotion();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const mod = e.metaKey || e.ctrlKey;
+      if (mod && e.key.toLowerCase() === "k" && !e.shiftKey) {
+        e.preventDefault();
+        if (isOpen) {
+          close();
+        } else {
+          open();
+        }
+      }
+      if (e.key === "Escape" && isOpen) {
+        close();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [isOpen, open, close]);
+
+  useEffect(() => {
+    if (isOpen) markRead();
+  }, [isOpen, markRead]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isOpen]);
+
+  if (pathname === "/chat") return null;
+
+  return (
+    <>
+      <ChatTrigger
+        isOpen={isOpen}
+        onOpen={open}
+        onClose={close}
+        hasUnread={hasUnread}
+      />
+
+      <AnimatePresence>
+        {isOpen && (
+          <>
+            <motion.div
+              key="chat-backdrop"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.18 }}
+              className="fixed inset-0 z-40 bg-background/45 backdrop-blur-sm sm:hidden"
+              onClick={close}
+            />
+            <motion.div
+              key="chat-panel"
+              data-lenis-prevent
+              data-lenis-prevent-wheel
+              data-lenis-prevent-touch
+              initial={
+                reduced ? { opacity: 0 } : { opacity: 0, y: 18, scale: 0.97 }
+              }
+              animate={
+                reduced ? { opacity: 1 } : { opacity: 1, y: 0, scale: 1 }
+              }
+              exit={
+                reduced ? { opacity: 0 } : { opacity: 0, y: 18, scale: 0.97 }
+              }
+              transition={{ duration: 0.22, ease: [0.2, 0, 0, 1] }}
+              className={cn(
+                "fixed z-50 flex flex-col overflow-hidden overscroll-contain",
+                "inset-x-0 bottom-0 top-0",
+                "sm:inset-auto sm:bottom-24 sm:right-6",
+                "sm:h-[min(720px,calc(100vh-7.5rem))] sm:w-[440px]",
+                "rounded-none sm:rounded-[32px]",
+                "bg-card shadow-[0_20px_50px_-10px_hsla(0,0%,0%,0.35)]",
+              )}
+              role="dialog"
+              aria-label="Volvox Assistant"
+            >
+              <ChatPanel variant="floating" />
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
+    </>
+  );
+}
+
+export function VolvoxAssistant() {
+  return (
+    <ChatProvider>
+      <AssistantInner />
+    </ChatProvider>
+  );
+}

--- a/src/components/ai/volvox-assistant.tsx
+++ b/src/components/ai/volvox-assistant.tsx
@@ -67,7 +67,7 @@ function AssistantInner() {
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
               transition={{ duration: 0.18 }}
-              className="fixed inset-0 z-40 bg-background/45 backdrop-blur-sm sm:hidden"
+              className="fixed inset-0 z-40 bg-background/45"
               onClick={close}
             />
             <motion.div
@@ -75,27 +75,21 @@ function AssistantInner() {
               data-lenis-prevent
               data-lenis-prevent-wheel
               data-lenis-prevent-touch
-              initial={
-                reduced ? { opacity: 0 } : { opacity: 0, y: 18, scale: 0.97 }
-              }
-              animate={
-                reduced ? { opacity: 1 } : { opacity: 1, y: 0, scale: 1 }
-              }
-              exit={
-                reduced ? { opacity: 0 } : { opacity: 0, y: 18, scale: 0.97 }
-              }
-              transition={{ duration: 0.22, ease: [0.2, 0, 0, 1] }}
+              initial={reduced ? { opacity: 0 } : { x: "100%", opacity: 0 }}
+              animate={reduced ? { opacity: 1 } : { x: 0, opacity: 1 }}
+              exit={reduced ? { opacity: 0 } : { x: "100%", opacity: 0 }}
+              transition={{ duration: 0.3, ease: [0.16, 1, 0.3, 1] }}
               className={cn(
-                "fixed z-50 flex flex-col overflow-hidden overscroll-contain",
-                "inset-x-0 bottom-0 top-0",
-                "sm:inset-auto sm:bottom-24 sm:right-6",
-                "sm:h-[min(720px,calc(100vh-7.5rem))] sm:w-[440px]",
-                "rounded-none sm:rounded-[32px]",
-                "bg-card shadow-[0_20px_50px_-10px_hsla(0,0%,0%,0.35)]",
+                "fixed z-50 flex flex-col overscroll-contain",
+                "inset-y-0 right-0",
+                "w-full sm:w-[440px]",
+                "bg-card shadow-2xl",
               )}
               role="dialog"
               aria-label="Volvox Assistant"
             >
+              {/* Gradient fade div on left edge of sheet - tweak w- and the gradient to get your desired effect */}
+              <div className="absolute inset-y-0 -left-4 w-8 pointer-events-none bg-gradient-to-l from-card via-card/95 to-transparent z-1000" />
               <ChatPanel variant="floating" />
             </motion.div>
           </>

--- a/src/components/cookie-consent-banner.tsx
+++ b/src/components/cookie-consent-banner.tsx
@@ -128,7 +128,7 @@ export function CookieConsentBanner() {
             animate={{ y: 0, opacity: 1, scale: 1 }}
             exit={{ y: 20, opacity: 0, scale: 0.95 }}
             transition={{ duration: 0.2 }}
-            className="fixed bottom-4 right-4 z-50 w-full max-w-[300px]"
+            className="fixed bottom-4 left-4 z-50 w-full max-w-[300px]"
           >
             <div
               className="rounded-lg border bg-background/95 backdrop-blur-sm shadow-xl p-4 relative"

--- a/src/components/providers/smooth-scroll.tsx
+++ b/src/components/providers/smooth-scroll.tsx
@@ -21,6 +21,7 @@ export function SmoothScroll({ children }: { children: React.ReactNode }) {
       orientation: "vertical",
       gestureOrientation: "vertical",
       smoothWheel: true,
+      prevent: (node) => node.hasAttribute("data-lenis-prevent"),
     });
 
     lenisRef.current = lenis;

--- a/src/lib/ai/chat-store.ts
+++ b/src/lib/ai/chat-store.ts
@@ -16,11 +16,100 @@ export interface PersistedChat {
 
 const STORAGE_KEY = "volvox-chat-history";
 const TTL_MS = 14 * 24 * 60 * 60 * 1000;
+const CHAT_ROLES = new Set(["user", "assistant", "system"]);
+const SURFACE_TOOL_TYPES = new Set([
+  "tool-surface_team_card",
+  "tool-surface_product_card",
+  "tool-surface_blog_card",
+]);
 
-function isValidStoredMessage(value: unknown): value is StoredChatMessage {
-  if (typeof value !== "object" || value === null) return false;
-  const m = value as { id?: unknown; role?: unknown };
-  return typeof m.id === "string" && typeof m.role === "string";
+function normalizeStoredMessage(value: unknown): StoredChatMessage | null {
+  if (typeof value !== "object" || value === null) return null;
+  const m = value as {
+    id?: unknown;
+    role?: unknown;
+    content?: unknown;
+    parts?: unknown;
+    createdAt?: unknown;
+  };
+  if (
+    typeof m.id !== "string" ||
+    typeof m.role !== "string" ||
+    !CHAT_ROLES.has(m.role)
+  ) {
+    return null;
+  }
+  const content =
+    typeof m.content === "string" ? m.content : getTextContent(m.parts);
+  return {
+    id: m.id,
+    role: m.role as StoredChatMessage["role"],
+    content,
+    parts: m.parts,
+    createdAt: typeof m.createdAt === "number" ? m.createdAt : undefined,
+  };
+}
+
+function isTextPart(
+  part: unknown,
+): part is { type: "text"; text: string; state?: string } {
+  if (typeof part !== "object" || part === null) return false;
+  const p = part as { type?: unknown; text?: unknown };
+  return p.type === "text" && typeof p.text === "string";
+}
+
+function isSurfaceToolPart(
+  part: unknown,
+): part is { type: string; input?: unknown; output?: unknown; state?: string } {
+  if (typeof part !== "object" || part === null) return false;
+  const p = part as { type?: unknown };
+  return typeof p.type === "string" && SURFACE_TOOL_TYPES.has(p.type);
+}
+
+function getTextContent(parts: unknown): string {
+  if (!Array.isArray(parts)) return "";
+  return parts
+    .filter(isTextPart)
+    .map((part) => part.text)
+    .join("")
+    .trim();
+}
+
+function sanitizeParts(
+  role: StoredChatMessage["role"],
+  content: string,
+  parts: unknown,
+): unknown[] | undefined {
+  const rawParts = Array.isArray(parts)
+    ? parts
+    : content
+      ? [{ type: "text", text: content }]
+      : [];
+  const visibleParts = rawParts.filter((part) => {
+    if (isTextPart(part)) return part.text.trim().length > 0;
+    return role === "assistant" && isSurfaceToolPart(part);
+  });
+  return visibleParts.length > 0 ? visibleParts : undefined;
+}
+
+function hasVisibleContent(message: StoredChatMessage): boolean {
+  if (message.role === "system") return false;
+  if (message.content.trim().length > 0) return true;
+  return Array.isArray(message.parts) && message.parts.some(isSurfaceToolPart);
+}
+
+function sanitizeStoredMessage(
+  message: StoredChatMessage,
+): StoredChatMessage | null {
+  const parts = sanitizeParts(message.role, message.content, message.parts);
+  const sanitized: StoredChatMessage = {
+    id: message.id,
+    role: message.role,
+    content: message.content,
+    createdAt: message.createdAt,
+    ...(parts ? { parts } : {}),
+  };
+  return hasVisibleContent(sanitized) ? sanitized : null;
 }
 
 function getStorage(): Storage | null {
@@ -48,7 +137,11 @@ export function loadChat(): PersistedChat | null {
       storage.removeItem(STORAGE_KEY);
       return null;
     }
-    const validMessages = parsed.messages.filter(isValidStoredMessage);
+    const validMessages = parsed.messages
+      .map(normalizeStoredMessage)
+      .filter((m): m is StoredChatMessage => m !== null)
+      .map(sanitizeStoredMessage)
+      .filter((m): m is StoredChatMessage => m !== null);
     if (validMessages.length === 0) {
       storage.removeItem(STORAGE_KEY);
       return null;
@@ -73,13 +166,26 @@ export function saveChat(data: {
   const storage = getStorage();
   if (!storage) return;
   try {
+    const filteredMessages = data.messages
+      .map(normalizeStoredMessage)
+      .filter((m): m is StoredChatMessage => m !== null)
+      .map(sanitizeStoredMessage)
+      .filter((m): m is StoredChatMessage => m !== null);
+    if (filteredMessages.length === 0) {
+      console.warn(
+        "[chat-store] saveChat: no valid messages to persist, skipping",
+      );
+      return;
+    }
     const payload: PersistedChat = {
-      messages: data.messages as StoredChatMessage[],
+      messages: filteredMessages,
       intent: data.intent,
       expiresAt: Date.now() + TTL_MS,
     };
     storage.setItem(STORAGE_KEY, JSON.stringify(payload));
-  } catch {}
+  } catch (err) {
+    console.error("[chat-store] saveChat failed:", err);
+  }
 }
 
 export function clearChat(): void {

--- a/src/lib/ai/chat-store.ts
+++ b/src/lib/ai/chat-store.ts
@@ -1,0 +1,95 @@
+export interface StoredChatMessage {
+  id: string;
+  role: "user" | "assistant" | "system";
+  content: string;
+  parts?: unknown;
+  createdAt?: number;
+}
+
+export type VisitorIntent = "beginner" | "professional" | "hirer";
+
+export interface PersistedChat {
+  messages: StoredChatMessage[];
+  intent: VisitorIntent | null;
+  expiresAt: number;
+}
+
+const STORAGE_KEY = "volvox-chat-history";
+const TTL_MS = 14 * 24 * 60 * 60 * 1000;
+
+function isValidStoredMessage(value: unknown): value is StoredChatMessage {
+  if (typeof value !== "object" || value === null) return false;
+  const m = value as { id?: unknown; role?: unknown };
+  return typeof m.id === "string" && typeof m.role === "string";
+}
+
+function getStorage(): Storage | null {
+  try {
+    if (typeof globalThis !== "undefined" && "localStorage" in globalThis) {
+      return (globalThis as { localStorage: Storage }).localStorage;
+    }
+  } catch {}
+  return null;
+}
+
+export function loadChat(): PersistedChat | null {
+  const storage = getStorage();
+  if (!storage) return null;
+  try {
+    const raw = storage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as PersistedChat;
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      !Array.isArray(parsed.messages) ||
+      typeof parsed.expiresAt !== "number"
+    ) {
+      storage.removeItem(STORAGE_KEY);
+      return null;
+    }
+    const validMessages = parsed.messages.filter(isValidStoredMessage);
+    if (validMessages.length === 0) {
+      storage.removeItem(STORAGE_KEY);
+      return null;
+    }
+    if (Date.now() > parsed.expiresAt) {
+      storage.removeItem(STORAGE_KEY);
+      return null;
+    }
+    return { ...parsed, messages: validMessages };
+  } catch {
+    try {
+      storage.removeItem(STORAGE_KEY);
+    } catch {}
+    return null;
+  }
+}
+
+export function saveChat(data: {
+  messages: unknown[];
+  intent: VisitorIntent | null;
+}): void {
+  const storage = getStorage();
+  if (!storage) return;
+  try {
+    const payload: PersistedChat = {
+      messages: data.messages as StoredChatMessage[],
+      intent: data.intent,
+      expiresAt: Date.now() + TTL_MS,
+    };
+    storage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  } catch {}
+}
+
+export function clearChat(): void {
+  const storage = getStorage();
+  if (!storage) return;
+  try {
+    storage.removeItem(STORAGE_KEY);
+  } catch {}
+}
+
+export function getChatTtlDays(): number {
+  return TTL_MS / (24 * 60 * 60 * 1000);
+}

--- a/src/lib/ai/cta-bank.ts
+++ b/src/lib/ai/cta-bank.ts
@@ -1,0 +1,72 @@
+import { DISCORD_URL, SITE_URL } from "@/lib/constants";
+import type { VisitorIntent } from "./types";
+
+export const DISCORD_INVITE = DISCORD_URL;
+export const TEAM_PAGE = `${SITE_URL}/team`;
+export const PRODUCTS_PAGE = `${SITE_URL}/products`;
+export const BLOG_PAGE = `${SITE_URL}/blog`;
+export const MENTORSHIP_SECTION = `${SITE_URL}/#mentorship`;
+export const HIRING_EMAIL = "bill@volvox.dev";
+
+const ctas: Record<
+  VisitorIntent,
+  {
+    welcomeIntro: string;
+    afterTeamMember: (name: string) => string;
+    afterProduct: (name: string) => string;
+    afterBlog: (title: string) => string;
+    afterCommunity: () => string;
+    noMatch: () => string;
+    fallback: () => string;
+  }
+> = {
+  beginner: {
+    welcomeIntro: `If you're new to coding, you're in the right place — most of our Discord started exactly there.`,
+    afterTeamMember: (name) =>
+      `${name} runs beginner-friendly office hours in our Discord. Drop in with your first question.`,
+    afterProduct: (name) =>
+      `Products like ${name} are open source — reading the code is one of the fastest ways to learn how real apps get built.`,
+    afterBlog: (title) =>
+      `If you enjoyed “${title},” check the author’s other posts — they're written for people learning in public.`,
+    afterCommunity: () =>
+      `Our Discord has a dedicated #beginners channel. No question is too small — Bill and the mentors answer daily.`,
+    noMatch: () =>
+      `If you're learning to code, the #beginners channel in our Discord is the warmest place to start.`,
+    fallback: () =>
+      `**Next step:** hop into the Discord — it's where most of the magic happens for new devs. → ${DISCORD_INVITE}`,
+  },
+  professional: {
+    welcomeIntro: `We have an active open-source org, technical deep-dives on the blog, and Discord channels per stack.`,
+    afterTeamMember: (name) =>
+      `${name} is the person to ping for collaboration. Their GitHub + Discord are on their profile.`,
+    afterProduct: (name) =>
+      `${name} is open source — PRs welcome. Tag the maintainer in your first issue.`,
+    afterBlog: (title) =>
+      `“${title}” is the kind of write-up we publish monthly. Subscribe via RSS or follow the blog page.`,
+    afterCommunity: () =>
+      `Our Discord has channels per stack (#react, #next, #mobile, #ai, etc.). DM any mentor to start a thread.`,
+    noMatch: () =>
+      `For technical work, the open-source repos under our GitHub org are the fastest way to collaborate.`,
+    fallback: () =>
+      `**Next step:** join the Discord to start contributing, or browse the open-source org. → ${DISCORD_INVITE}`,
+  },
+  hirer: {
+    welcomeIntro: `I'll surface hireable team members with their portfolios, contact channels, and the fastest path to Bill (CEO).`,
+    afterTeamMember: (name) =>
+      `${name} is open to work — tap the Hire button on their card or DM them on LinkedIn.`,
+    afterProduct: (name) =>
+      `The team behind ${name} is the same team you'd be hiring. Bill is the fastest route to scope an engagement.`,
+    afterBlog: (title) =>
+      `If the engineering voice in “${title}” is what you need on your team, I'll match you with the right author.`,
+    afterCommunity: () =>
+      `For hires, email Bill directly: ${HIRING_EMAIL}. Or view the team page for all hireable members.`,
+    noMatch: () =>
+      `For hiring, the team page lists who's available — and Bill is the fastest route for a warm intro.`,
+    fallback: () =>
+      `**Next step:** view the team page to shortlist candidates, or email Bill (CEO) at ${HIRING_EMAIL} for a warm intro.`,
+  },
+};
+
+export function ctaFor(intent: VisitorIntent) {
+  return ctas[intent];
+}

--- a/src/lib/ai/intent.ts
+++ b/src/lib/ai/intent.ts
@@ -1,0 +1,139 @@
+import type { IntentDetectionResult, VisitorIntent } from "./types";
+
+export type { IntentDetectionResult, VisitorIntent } from "./types";
+
+const BEGINNER_PATTERNS: RegExp[] = [
+  /\bbeginner\b/i,
+  /\bjust starting\b/i,
+  /\bnew to (coding|programming|tech|development)\b/i,
+  /\bstart(ing)? (to )?(code|program|learn)\b/i,
+  /\blearn(ing)? to code\b/i,
+  /\bfirst (app|project|website|job)\b/i,
+  /\bstudent\b/i,
+  /\bself[- ]taught\b/i,
+  /\bcoding bootcamp\b/i,
+  /\bcs degree\b/i,
+  /\bcareer (switch|change)\b/i,
+];
+
+const HIRER_PATTERNS: RegExp[] = [
+  /\bhire\b/i,
+  /\bhiring\b/i,
+  /\bavailable for (work|hire|hiring|projects)\b/i,
+  /\blooking for (a |an )?dev(eloper)?\b/i,
+  /\bfreelance\b/i,
+  /\bcontract(ing)?\b/i,
+  /\bwe('re| are) (hiring|looking|recruiting)\b/i,
+  /\bneed (a |an )?(developer|engineer|designer|frontend|backend|fullstack)\b/i,
+  /\bfor (our|my|the) (team|company|startup|project|business)\b/i,
+  /\bcan (you|he|she|they) (work|build|do) (for|with) (us|me)\b/i,
+];
+
+const PROFESSIONAL_PATTERNS: RegExp[] = [
+  /\breact\b/i,
+  /\btypescript\b/i,
+  /\bjavascript\b/i,
+  /\bnext\.?js\b/i,
+  /\btailwind\b/i,
+  /\bopen[- ]source\b/i,
+  /\bcontribut(e|ing|ion)\b/i,
+  /\bnode\.?js\b/i,
+  /\bbackend\b/i,
+  /\bfrontend\b/i,
+  /\bfull[- ]?stack\b/i,
+  /\bsystem design\b/i,
+  /\bapi\b/i,
+  /\bdatabase\b/i,
+  /\barchitecture\b/i,
+  /\bmobile (dev|development|app)\b/i,
+  /\breact native\b/i,
+];
+
+const INTENT_HINTS: Record<Exclude<VisitorIntent, null>, RegExp[]> = {
+  beginner: BEGINNER_PATTERNS,
+  hirer: HIRER_PATTERNS,
+  professional: PROFESSIONAL_PATTERNS,
+};
+
+export function detectIntentFromText(text: string): VisitorIntent {
+  const text_ = text.toLowerCase();
+  if (BEGINNER_PATTERNS.some((r) => r.test(text_))) return "beginner";
+  if (HIRER_PATTERNS.some((r) => r.test(text_))) return "hirer";
+  if (PROFESSIONAL_PATTERNS.some((r) => r.test(text_))) return "professional";
+  return "professional";
+}
+
+const DEFAULT_RESULT: IntentDetectionResult = {
+  intent: "professional",
+  confidence: 0,
+  signals: { beginner: 0, professional: 0, hirer: 0 },
+};
+
+export function detectIntent(
+  messages: { role: string; content: string }[],
+  options: { explicitSeed?: VisitorIntent | null } = {},
+): IntentDetectionResult {
+  const recent = messages
+    .filter((m) => m.role === "user" && m.content.trim().length > 0)
+    .slice(-4);
+
+  if (recent.length === 0) {
+    return options.explicitSeed
+      ? {
+          intent: options.explicitSeed,
+          confidence: 0.4,
+          signals: { beginner: 0, professional: 0, hirer: 0 },
+        }
+      : DEFAULT_RESULT;
+  }
+
+  const scores: Record<VisitorIntent, number> = {
+    beginner: 0,
+    professional: 0,
+    hirer: 0,
+  };
+
+  for (let i = 0; i < recent.length; i++) {
+    const m = recent[i];
+    const text = m.content;
+    const recencyBoost = 1 + (i / recent.length) * 0.5;
+    for (const intent of Object.keys(INTENT_HINTS) as VisitorIntent[]) {
+      const matches = INTENT_HINTS[intent].reduce(
+        (count, pattern) => (pattern.test(text) ? count + 1 : count),
+        0,
+      );
+      scores[intent] += matches * recencyBoost;
+    }
+  }
+
+  if (options.explicitSeed) {
+    scores[options.explicitSeed] += 1.5;
+  }
+
+  const total = scores.beginner + scores.professional + scores.hirer;
+  const winner = (Object.entries(scores) as [VisitorIntent, number][]).reduce(
+    (best, [intent, score]) => (score > best[1] ? [intent, score] : best),
+    ["professional", 0] as [VisitorIntent, number],
+  );
+
+  const intent =
+    winner[1] > 0 ? winner[0] : (options.explicitSeed ?? "professional");
+  const confidence = total === 0 ? 0.3 : Math.min(1, winner[1] / (total + 1));
+
+  return { intent, confidence, signals: scores };
+}
+
+export const INTENT_LABELS: Record<VisitorIntent, string> = {
+  beginner: "Learning to code",
+  professional: "Developer / peer",
+  hirer: "Looking to hire",
+};
+
+export const INTENT_DESCRIPTIONS: Record<VisitorIntent, string> = {
+  beginner:
+    "I'll show you the friendliest on-ramp: mentors, beginner-friendly Discord channels, and stories from devs who started where you are.",
+  professional:
+    "I'll point you at open-source repos to contribute, technical deep-dives, and the right expert for your stack.",
+  hirer:
+    "I'll surface hireable team members with their portfolios, contact channels, and the fastest path to Bill (CEO) for a warm intro.",
+};

--- a/src/lib/ai/provider.ts
+++ b/src/lib/ai/provider.ts
@@ -1,48 +1,34 @@
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 
-/**
- * Provider switcher for the Volvox Assistant.
- *
- * Currently active: OpenRouter (free models for development/testing).
- * When ready for production, uncomment the Z.AI / GLM block below and set
- * Z_AI_API_KEY in your env. The model config lives entirely in env vars so
- * no code changes are needed to swap.
- */
+let _chatModel: ReturnType<ReturnType<typeof createOpenAICompatible>> | null =
+  null;
 
-// ── ACTIVE: OpenRouter (free tier) ────────────────────────────────────
-// Free models on OpenRouter: https://openrouter.ai/models?q=free
-// Set OPENROUTER_API_KEY in your .env (or .env.local) file.
-const openrouterApiKey = process.env.OPENROUTER_API_KEY;
-if (!openrouterApiKey) {
-  throw new Error(
-    "OPENROUTER_API_KEY is required. Set it in your .env file or environment variables.",
-  );
+function getZaiModel() {
+  const apiKey = process.env.Z_AI_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "Z_AI_API_KEY is required. Set it in your .env file or environment variables. Get a key at https://z.ai",
+    );
+  }
+  const zai = createOpenAICompatible({
+    name: "zai",
+    baseURL: process.env.Z_AI_BASE_URL ?? "https://api.z.ai/api/paas/v4",
+    apiKey,
+  });
+  return zai(process.env.Z_AI_MODEL ?? "glm-5.1");
 }
 
-const openrouter = createOpenAICompatible({
-  name: "openrouter",
-  baseURL: process.env.OPENROUTER_BASE_URL ?? "https://openrouter.ai/api/v1",
-  apiKey: openrouterApiKey,
-});
+export function getChatModel() {
+  if (!_chatModel) {
+    _chatModel = getZaiModel();
+  }
+  return _chatModel;
+}
 
-const openrouterModelId =
-  process.env.OPENROUTER_MODEL ?? "moonshotai/kimi-k2.6:free";
-
-export const chatModel = openrouter(openrouterModelId);
-
-// ── DISABLED: Z.AI GLM (uncomment when ready for production) ──────────
-// const zai = createOpenAI({
-// 	baseURL: process.env.Z_AI_BASE_URL ?? "https://api.z.ai/api/paas/v4/",
-// 	apiKey: process.env.Z_AI_API_KEY ?? "",
-// });
-// const zaiModelId = process.env.Z_AI_MODEL ?? "glm-4.5";
-// export const chatModel = zai(zaiModelId);
+const modelId = process.env.Z_AI_MODEL ?? "glm-5.1";
 
 export const chatProviderInfo = {
-  provider: "openrouter" as const,
-  model: openrouterModelId,
-  baseURL: process.env.OPENROUTER_BASE_URL ?? "https://openrouter.ai/api/v1",
-  // provider: "z-ai",
-  // model: zaiModelId,
-  // baseURL: process.env.Z_AI_BASE_URL ?? "https://api.z.ai/api/paas/v4/",
+  provider: "z-ai" as const,
+  model: modelId,
+  baseURL: process.env.Z_AI_BASE_URL ?? "https://api.z.ai/api/paas/v4",
 } as const;

--- a/src/lib/ai/provider.ts
+++ b/src/lib/ai/provider.ts
@@ -12,10 +12,17 @@ import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 // ── ACTIVE: OpenRouter (free tier) ────────────────────────────────────
 // Free models on OpenRouter: https://openrouter.ai/models?q=free
 // Set OPENROUTER_API_KEY in your .env (or .env.local) file.
+const openrouterApiKey = process.env.OPENROUTER_API_KEY;
+if (!openrouterApiKey) {
+  throw new Error(
+    "OPENROUTER_API_KEY is required. Set it in your .env file or environment variables.",
+  );
+}
+
 const openrouter = createOpenAICompatible({
   name: "openrouter",
   baseURL: process.env.OPENROUTER_BASE_URL ?? "https://openrouter.ai/api/v1",
-  apiKey: process.env.OPENROUTER_API_KEY ?? "",
+  apiKey: openrouterApiKey,
 });
 
 const openrouterModelId =

--- a/src/lib/ai/provider.ts
+++ b/src/lib/ai/provider.ts
@@ -1,0 +1,41 @@
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+
+/**
+ * Provider switcher for the Volvox Assistant.
+ *
+ * Currently active: OpenRouter (free models for development/testing).
+ * When ready for production, uncomment the Z.AI / GLM block below and set
+ * Z_AI_API_KEY in your env. The model config lives entirely in env vars so
+ * no code changes are needed to swap.
+ */
+
+// ── ACTIVE: OpenRouter (free tier) ────────────────────────────────────
+// Free models on OpenRouter: https://openrouter.ai/models?q=free
+// Set OPENROUTER_API_KEY in your .env (or .env.local) file.
+const openrouter = createOpenAICompatible({
+  name: "openrouter",
+  baseURL: process.env.OPENROUTER_BASE_URL ?? "https://openrouter.ai/api/v1",
+  apiKey: process.env.OPENROUTER_API_KEY ?? "",
+});
+
+const openrouterModelId =
+  process.env.OPENROUTER_MODEL ?? "moonshotai/kimi-k2.6:free";
+
+export const chatModel = openrouter(openrouterModelId);
+
+// ── DISABLED: Z.AI GLM (uncomment when ready for production) ──────────
+// const zai = createOpenAI({
+// 	baseURL: process.env.Z_AI_BASE_URL ?? "https://api.z.ai/api/paas/v4/",
+// 	apiKey: process.env.Z_AI_API_KEY ?? "",
+// });
+// const zaiModelId = process.env.Z_AI_MODEL ?? "glm-4.5";
+// export const chatModel = zai(zaiModelId);
+
+export const chatProviderInfo = {
+  provider: "openrouter" as const,
+  model: openrouterModelId,
+  baseURL: process.env.OPENROUTER_BASE_URL ?? "https://openrouter.ai/api/v1",
+  // provider: "z-ai",
+  // model: zaiModelId,
+  // baseURL: process.env.Z_AI_BASE_URL ?? "https://api.z.ai/api/paas/v4/",
+} as const;

--- a/src/lib/ai/rate-limit.ts
+++ b/src/lib/ai/rate-limit.ts
@@ -11,12 +11,19 @@ const redis =
     : null;
 
 let limiter: Ratelimit | null = null;
+let anonLimiter: Ratelimit | null = null;
 if (redis) {
   try {
     limiter = new Ratelimit({
       redis,
       limiter: Ratelimit.slidingWindow(20, "10 m"),
       prefix: "volvox:chat",
+      analytics: false,
+    });
+    anonLimiter = new Ratelimit({
+      redis,
+      limiter: Ratelimit.slidingWindow(200, "10 m"),
+      prefix: "volvox:chat:anon",
       analytics: false,
     });
   } catch (err) {
@@ -41,11 +48,13 @@ const PASS_THROUGH: RateLimitResult = {
 export async function assertChatRateLimit(
   identifier: string,
 ): Promise<RateLimitResult> {
-  if (!limiter) {
+  if (!limiter || !anonLimiter) {
     return PASS_THROUGH;
   }
   try {
-    const result = await limiter.limit(identifier);
+    const isAnon = identifier === "anon";
+    const rl = isAnon ? anonLimiter : limiter;
+    const result = await rl.limit(isAnon ? "anon" : identifier);
     return {
       success: result.success,
       limit: result.limit,

--- a/src/lib/ai/rate-limit.ts
+++ b/src/lib/ai/rate-limit.ts
@@ -1,0 +1,59 @@
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+import { reportError } from "@/lib/logger";
+
+const REDIS_URL = process.env.UPSTASH_REDIS_REST_URL;
+const REDIS_TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+const redis =
+  REDIS_URL && REDIS_TOKEN
+    ? new Redis({ url: REDIS_URL, token: REDIS_TOKEN })
+    : null;
+
+let limiter: Ratelimit | null = null;
+if (redis) {
+  try {
+    limiter = new Ratelimit({
+      redis,
+      limiter: Ratelimit.slidingWindow(20, "10 m"),
+      prefix: "volvox:chat",
+      analytics: false,
+    });
+  } catch (err) {
+    reportError("Failed to initialize chat rate limiter", err);
+  }
+}
+
+export interface RateLimitResult {
+  success: boolean;
+  limit: number;
+  remaining: number;
+  reset: number;
+}
+
+const PASS_THROUGH: RateLimitResult = {
+  success: true,
+  limit: 20,
+  remaining: 20,
+  reset: 0,
+};
+
+export async function assertChatRateLimit(
+  identifier: string,
+): Promise<RateLimitResult> {
+  if (!limiter) {
+    return PASS_THROUGH;
+  }
+  try {
+    const result = await limiter.limit(identifier);
+    return {
+      success: result.success,
+      limit: result.limit,
+      remaining: result.remaining,
+      reset: result.reset,
+    };
+  } catch (err) {
+    reportError("Chat rate limit check failed", err);
+    return PASS_THROUGH;
+  }
+}

--- a/src/lib/ai/system-prompt.ts
+++ b/src/lib/ai/system-prompt.ts
@@ -52,6 +52,7 @@ Build great software while fostering the next generation of developers through m
 5. **Format with markdown.** Use short paragraphs, bullet lists, and **bold** for names and product titles. Keep responses under 200 words unless the user asks for more.
 6. **If the user asks something off-topic**, briefly answer (one sentence) then pivot to a relevant Volvox hook.
 7. **Match the persona's voice** (see persona blocks below).
+8. **Keep the work invisible.** Never reveal chain-of-thought, private reasoning, tool names, tool calls, intermediate steps, or phrases like "I looked up" / "I used a tool". Think and use tools silently, then present only the final user-facing answer.
 `;
 
 const PERSONA_BEGINNER = `## Persona: BEGINNER (learning to code)
@@ -154,7 +155,7 @@ You have these tools available:
 4. Compose the answer with the persona's tone.
 5. Close with the persona's CTA.
 
-You can call multiple tools in one turn. After the tool results come back, synthesize the final response.
+You can call multiple tools in one turn. After the tool results come back, synthesize the final response. Do not narrate the tool workflow or expose intermediate reasoning.
 
 Today's date is ${new Date().toISOString().slice(0, 10)}.
 `;

--- a/src/lib/ai/system-prompt.ts
+++ b/src/lib/ai/system-prompt.ts
@@ -1,0 +1,164 @@
+import {
+  DISCORD_URL,
+  GITHUB_URL,
+  SITE_DESCRIPTION,
+  SITE_NAME,
+  SITE_URL,
+} from "@/lib/constants";
+import type { VisitorIntent } from "./types";
+
+const MASTER_PREAMBLE = `You are the **Volvox Assistant** — a goal-oriented AI agent that lives on the ${SITE_NAME} website. Your purpose is to help visitors learn about ${SITE_NAME}, its people, products, and community, and to guide them toward a relevant next step.
+
+## About ${SITE_NAME}
+
+${SITE_DESCRIPTION}
+
+${SITE_NAME} is a software development company and learning community, founded in 2020 by Bill Chirico. The company pairs experienced developers with aspiring programmers through real-world open-source projects.
+
+### Mission
+Build great software while fostering the next generation of developers through mentorship and open source.
+
+### What we offer
+- **Mentorship program** — seasoned developers mentor those starting their journey through real production projects.
+- **Open-source development** — every product is built in the open, providing learning opportunities.
+- **Developer community** — an active Discord community for collaboration, code help, and career advice.
+- **Product development** — real applications serving real user needs.
+
+### Products (overview)
+1. **Sobers** (sobers.app) — A free accountability app for sponsors and sponsees in 12-step recovery programs. iOS, Android, Web. Built with React Native + Expo. No paywalls, no ads.
+2. **Decision Jar** (decisionjar.app) — A fun decision-making app: shake your phone to pick from custom jars. AI suggestions, QR sharing, decision history, streaks. iOS, Android.
+
+### Team (overview)
+- **Bill Chirico** — CEO & Founder. 20+ years. Mentorship since 2018. Created Sobers and Decision Jar.
+- **Eleftheria Batsou** — Developer Advocate. Public speaker, meetup co-organizer, community builder.
+- **Hossain Jahed (rabden)** — Frontend Developer. Next.js, React, TypeScript, Tailwind, Framer Motion, GSAP. Available for hire.
+- **Mohsin Mukhtar** — Developer. Node, React Native, system design, AI.
+- **Madhurima Gupta** — Digital Marketing Specialist. SEO, paid ads, brand building.
+- **Olivia Hart** — Digital Marketing Specialist. Content, social media, paid social.
+
+### Community
+- **Discord** — ${DISCORD_URL}
+- **GitHub** — ${GITHUB_URL}
+- **Blog** — ${SITE_URL}/blog (12 posts, technical + community stories)
+- **Products** — ${SITE_URL}/products
+- **Team** — ${SITE_URL}/team
+
+## Critical rules
+
+1. **Never invent facts.** Only surface information returned by your tools. If you don't know, say so and point to the relevant Volvox page.
+2. **Always use tools** when the user asks about people, products, blog posts, or community — don't paraphrase from memory.
+3. **When you mention a team member, product, or blog post, use the surface tool** (e.g. surface_team_card) to embed a clickable card. The user can then tap it.
+4. **End ~70% of responses with a CTA** drawn from the persona's CTA bank. Medium conversion tone — be helpful, not pushy, but always close with a clear next step.
+5. **Format with markdown.** Use short paragraphs, bullet lists, and **bold** for names and product titles. Keep responses under 200 words unless the user asks for more.
+6. **If the user asks something off-topic**, briefly answer (one sentence) then pivot to a relevant Volvox hook.
+7. **Match the persona's voice** (see persona blocks below).
+`;
+
+const PERSONA_BEGINNER = `## Persona: BEGINNER (learning to code)
+
+You are warm, encouraging, and jargon-free. Translate tech terms. Lean on analogies.
+
+Tone:
+- "You're in the right place" energy.
+- Celebrate small steps. Most of our Discord started exactly where the visitor is.
+- Never gatekeep. Never assume the visitor knows what "open source" or "Discord" means — explain when relevant.
+
+What to highlight:
+- **Mentors** (Bill, Eleftheria) — "These are the people who'd answer your first questions."
+- **#beginners channel** on Discord.
+- **Open source** as a way to learn by reading real production code.
+- **Interviews on the blog** with devs who switched careers or started late.
+- **Sobers / Decision Jar** as proof that real products get shipped by community members.
+
+Avoid:
+- Technical jargon without explanation.
+- Stacking too many tools. Pick one or two routes per response.
+- Pressuring. Suggest, don't push.
+
+Fallback CTA: invite to Discord's #beginners channel.
+`;
+
+const PERSONA_PROFESSIONAL = `## Persona: PROFESSIONAL (peer developer)
+
+You are peer-to-peer, efficient, and specific. No fluff, no hand-holding.
+
+Tone:
+- Treat the visitor as a fellow engineer.
+- Cite specific technologies, repos, and people.
+- Skip explanations of well-known concepts.
+
+What to highlight:
+- **Open source repos** for contribution (VolvoxCommunity org on GitHub).
+- **Named experts per stack** — Hossain for Next.js/GSAP, Mohsin for Node/React Native/AI, Bill for system design/architecture.
+- **Technical blog posts** — point to specific articles that match the question.
+- **Discord channels per stack** — #react, #next, #mobile, #ai, #systems, #career.
+- **Interviews** with industry builders (Brad on AI, Johanna on personal projects, Unes on robotics, etc.).
+
+Avoid:
+- Beginner explanations.
+- "Welcome to our community!" preambles.
+- Recommending the Discord without a specific channel or thread to join.
+
+Fallback CTA: link to the relevant GitHub repo or technical blog post.
+`;
+
+const PERSONA_HIRER = `## Persona: HIRER (looking to hire)
+
+You are direct, businesslike, and lead with people.
+
+Tone:
+- Get to the point. Time is money.
+- Lead with hireable team members' portfolios, not generic team bios.
+- Provide direct contact channels (email, LinkedIn) whenever possible.
+
+What to highlight:
+- **Hireable members** — surface them with their full portfolio. Today, Hossain (rabden) is the explicitly hireable member on the site. For other work, Bill (CEO) is the routing point.
+- **Skills match** — when the visitor mentions a stack, surface the team member with the deepest expertise in it.
+- **Speed-to-contact** — always offer the email (bill@volvox.dev) or a direct LinkedIn link.
+- **Past project evidence** — link to projects listed in the member's portfolio.
+
+Avoid:
+- Generic "we'd love to work with you" answers.
+- Burying the contact details.
+- Recommending the Discord for hires.
+
+Fallback CTA: bill@volvox.dev or the team page.
+`;
+
+const PERSONA_BLOCKS: Record<VisitorIntent, string> = {
+  beginner: PERSONA_BEGINNER,
+  professional: PERSONA_PROFESSIONAL,
+  hirer: PERSONA_HIRER,
+};
+
+const TOOL_GUIDANCE = `
+## How to use your tools
+
+You have these tools available:
+
+- **get_team_members** — list team members. Use filters: { expertise: string[], type, isHireable }.
+- **get_team_member** — fetch full member profile (bio, projects, socials). Use this when the user asks for more detail on a specific person.
+- **get_products** — list all products (Sobers, Decision Jar).
+- **get_product** — fetch full product details (features, FAQ, links).
+- **get_blog_posts** — list blog posts. Use filters: { tag, query, limit }.
+- **get_blog_post** — fetch full blog post content.
+- **get_community_info** — fetch community/Discord/GitHub info.
+- **surface_team_card** — render an inline clickable team member card. **Call this when you mention a specific person.**
+- **surface_product_card** — render an inline clickable product card. **Call this when you mention a specific product.**
+- **surface_blog_card** — render an inline clickable blog card. **Call this when you mention a specific blog post.**
+
+**Workflow pattern:**
+1. Detect what the user is asking.
+2. Call a list/fetch tool to get the data.
+3. If mentioning a specific entity (person / product / post), call the corresponding surface_* tool.
+4. Compose the answer with the persona's tone.
+5. Close with the persona's CTA.
+
+You can call multiple tools in one turn. After the tool results come back, synthesize the final response.
+
+Today's date is ${new Date().toISOString().slice(0, 10)}.
+`;
+
+export function buildSystemPrompt(intent: VisitorIntent): string {
+  return [MASTER_PREAMBLE, PERSONA_BLOCKS[intent], TOOL_GUIDANCE].join("\n\n");
+}

--- a/src/lib/ai/tool-handlers.ts
+++ b/src/lib/ai/tool-handlers.ts
@@ -337,8 +337,8 @@ export async function getBlogPostBySlug(
 
 export function getCommunityInfo(): CommunityInfo {
   return {
-    discord: "https://discord.gg/8ahXACdamN",
-    github: "https://github.com/VolvoxCommunity",
+    discord: DISCORD_URL,
+    github: GITHUB_URL,
     blog: `${SITE_URL}/blog`,
     products: `${SITE_URL}/products`,
     team: `${SITE_URL}/team`,

--- a/src/lib/ai/tool-handlers.ts
+++ b/src/lib/ai/tool-handlers.ts
@@ -1,4 +1,4 @@
-import { SITE_URL } from "@/lib/constants";
+import { DISCORD_URL, GITHUB_URL, SITE_URL } from "@/lib/constants";
 import {
   getAllExtendedProducts,
   getAllProducts,
@@ -71,6 +71,7 @@ export interface ProductDetail {
   };
   updatedAt?: string;
   pageUrl: string;
+  image: string;
 }
 
 export interface BlogPostSummary {
@@ -172,11 +173,21 @@ function shortTagline(p: Product): string {
   return (first ?? p.description).slice(0, 140);
 }
 
+let _productIdToSlug: Map<string, string> | null = null;
+
 function getProductSlugFromId(id: string): string {
-  if (id.includes("ee7a459b") || id.startsWith("ee7a459b")) return "sobers";
-  if (id.includes("a3f8b2c1") || id.startsWith("a3f8b2c1"))
-    return "decision-jar";
-  return id;
+  if (!_productIdToSlug) {
+    _productIdToSlug = new Map(
+      getAllExtendedProducts().map((p) => [p.id, p.slug]),
+    );
+  }
+  return _productIdToSlug.get(id) ?? id;
+}
+
+function getProductImage(slug: string): string {
+  const products = getAllProducts();
+  const product = products.find((p) => getProductSlugFromId(p.id) === slug);
+  return product?.image ?? `/images/product/${slug}.png`;
 }
 
 function toProductDetail(p: ExtendedProduct): ProductDetail {
@@ -193,6 +204,7 @@ function toProductDetail(p: ExtendedProduct): ProductDetail {
     links: p.links,
     updatedAt: p.updatedAt,
     pageUrl: `${SITE_URL}/products/${p.slug}`,
+    image: getProductImage(p.slug),
   };
 }
 

--- a/src/lib/ai/tool-handlers.ts
+++ b/src/lib/ai/tool-handlers.ts
@@ -1,0 +1,350 @@
+import { SITE_URL } from "@/lib/constants";
+import {
+  getAllExtendedProducts,
+  getAllProducts,
+  getAllTeamMembers,
+} from "@/lib/content";
+import type {
+  BlogPost,
+  ExtendedProduct,
+  Product,
+  TeamMember,
+} from "@/lib/types";
+
+export interface TeamMemberSummary {
+  slug: string;
+  name: string;
+  role: string;
+  tagline: string;
+  type: string;
+  expertise: string[];
+  isHireable: boolean;
+  avatar: string;
+}
+
+export interface TeamMemberDetail {
+  slug: string;
+  name: string;
+  role: string;
+  tagline: string;
+  bio: string;
+  expertise: string[];
+  projects: Array<{
+    name: string;
+    description: string;
+    role?: string;
+    url?: string;
+  }>;
+  githubUrl?: string;
+  linkedinUrl?: string;
+  email?: string;
+  isHireable: boolean;
+  avatar: string;
+  profileUrl: string;
+}
+
+export interface ProductSummary {
+  slug: string;
+  name: string;
+  tagline: string;
+  description: string;
+  demoUrl?: string;
+  isOpenSource: boolean;
+  image: string;
+}
+
+export interface ProductDetail {
+  slug: string;
+  name: string;
+  tagline: string;
+  type?: string;
+  description: string;
+  longDescription: string;
+  features: string[];
+  techStack: string[];
+  faq: Array<{ question: string; answer: string }>;
+  links: {
+    github?: string;
+    demo?: string;
+    appStore?: string;
+    playStore?: string;
+  };
+  updatedAt?: string;
+  pageUrl: string;
+}
+
+export interface BlogPostSummary {
+  slug: string;
+  title: string;
+  excerpt: string;
+  date: string;
+  tags: string[];
+  authorName: string;
+  readingTime: number;
+  url: string;
+}
+
+export interface BlogPostDetail {
+  slug: string;
+  title: string;
+  excerpt: string;
+  date: string;
+  tags: string[];
+  authorName: string;
+  readingTime: number;
+  banner?: string;
+  bodyExcerpt: string;
+  url: string;
+}
+
+export interface CommunityInfo {
+  discord: string;
+  github: string;
+  blog: string;
+  products: string;
+  team: string;
+  mentorshipPitch: string;
+  hiringEmail: string;
+  siteUrl: string;
+}
+
+function toTeamMemberSummary(m: TeamMember): TeamMemberSummary {
+  const isMentee = m.type === "mentee";
+  return {
+    slug: m.slug,
+    name: m.name,
+    role: isMentee ? "Mentee" : m.role,
+    tagline: m.tagline,
+    type: m.type,
+    expertise: isMentee ? [] : m.expertise,
+    isHireable: m.isHireable ?? false,
+    avatar: m.avatar,
+  };
+}
+
+function toTeamMemberDetail(m: TeamMember): TeamMemberDetail {
+  const isMentee = m.type === "mentee";
+  const projects = isMentee
+    ? []
+    : ((
+        m as {
+          projects?: Array<{
+            name: string;
+            description: string;
+            role?: string;
+            url?: string;
+          }>;
+        }
+      ).projects ?? []);
+  const bio = isMentee ? `${m.goals} ${m.progress}` : m.bio;
+  const expertise = isMentee ? [] : m.expertise;
+  return {
+    slug: m.slug,
+    name: m.name,
+    role: isMentee ? "Mentee" : m.role,
+    tagline: m.tagline,
+    bio,
+    expertise,
+    projects,
+    githubUrl: m.githubUrl,
+    linkedinUrl: m.linkedinUrl,
+    email: m.email,
+    isHireable: m.isHireable ?? false,
+    avatar: m.avatar,
+    profileUrl: `${SITE_URL}/team/${m.slug}`,
+  };
+}
+
+function toProductSummary(p: Product): ProductSummary {
+  return {
+    slug: getProductSlugFromId(p.id),
+    name: p.name,
+    tagline: shortTagline(p),
+    description: p.description,
+    demoUrl: p.demoUrl,
+    isOpenSource: Boolean(p.githubUrl),
+    image: p.image,
+  };
+}
+
+function shortTagline(p: Product): string {
+  const first = p.description.split(/[.!?]/)[0]?.trim();
+  return (first ?? p.description).slice(0, 140);
+}
+
+function getProductSlugFromId(id: string): string {
+  if (id.includes("ee7a459b") || id.startsWith("ee7a459b")) return "sobers";
+  if (id.includes("a3f8b2c1") || id.startsWith("a3f8b2c1"))
+    return "decision-jar";
+  return id;
+}
+
+function toProductDetail(p: ExtendedProduct): ProductDetail {
+  return {
+    slug: p.slug,
+    name: p.name,
+    tagline: p.tagline,
+    type: p.type,
+    description: p.description,
+    longDescription: p.longDescription,
+    features: p.features,
+    techStack: p.techStack,
+    faq: p.faq,
+    links: p.links,
+    updatedAt: p.updatedAt,
+    pageUrl: `${SITE_URL}/products/${p.slug}`,
+  };
+}
+
+function toBlogPostSummary(p: BlogPost): BlogPostSummary {
+  return {
+    slug: p.slug,
+    title: p.title,
+    excerpt: p.excerpt,
+    date: p.date,
+    tags: p.tags,
+    authorName: p.author?.name ?? "Volvox",
+    readingTime: p.readingTime,
+    url: `${SITE_URL}/blog/${p.slug}`,
+  };
+}
+
+function toBlogPostDetail(p: BlogPost): BlogPostDetail {
+  const plain = p.content
+    .replace(/```[\s\S]*?```/g, "")
+    .replace(/[#*_`>]/g, "");
+  const trimmed = plain.replace(/\s+/g, " ").trim().slice(0, 600);
+  return {
+    slug: p.slug,
+    title: p.title,
+    excerpt: p.excerpt,
+    date: p.date,
+    tags: p.tags,
+    authorName: p.author?.name ?? "Volvox",
+    readingTime: p.readingTime,
+    banner: p.banner,
+    bodyExcerpt: trimmed,
+    url: `${SITE_URL}/blog/${p.slug}`,
+  };
+}
+
+export interface ListTeamMembersArgs {
+  expertise?: string[];
+  type?: "mentor" | "builder" | "marketer" | "mentee";
+  isHireable?: boolean;
+}
+
+export function listTeamMembers(
+  args: ListTeamMembersArgs = {},
+): TeamMemberSummary[] {
+  const members = getAllTeamMembers();
+  let filtered = members;
+  if (args.type) {
+    filtered = filtered.filter((m) => m.type === args.type);
+  }
+  if (args.isHireable !== undefined) {
+    filtered = filtered.filter(
+      (m) => (m.isHireable ?? false) === args.isHireable,
+    );
+  }
+  if (args.expertise && args.expertise.length > 0) {
+    const lower = args.expertise.map((e: string) => e.toLowerCase());
+    filtered = filtered.filter((m) => {
+      if (m.type === "mentee") return false;
+      const skills = m.expertise.map((e: string) => e.toLowerCase());
+      return lower.some((e: string) =>
+        skills.some((s: string) => s.includes(e)),
+      );
+    });
+  }
+  return filtered.map(toTeamMemberSummary);
+}
+
+export function getTeamMemberBySlug(slug: string): TeamMemberDetail | null {
+  const members = getAllTeamMembers();
+  const m = members.find((mem) => mem.slug === slug);
+  if (!m) return null;
+  return toTeamMemberDetail(m);
+}
+
+export function listProducts(): ProductSummary[] {
+  const products = getAllProducts();
+  return products.map(toProductSummary);
+}
+
+export function getProductBySlug(slug: string): ProductDetail | null {
+  const products = getAllExtendedProducts();
+  const p = products.find((prod) => prod.slug === slug);
+  if (!p) return null;
+  return toProductDetail(p);
+}
+
+export interface ListBlogPostsArgs {
+  tag?: string;
+  query?: string;
+  limit?: number;
+}
+
+export async function listBlogPosts(
+  args: ListBlogPostsArgs = {},
+): Promise<BlogPostSummary[]> {
+  const { getAllPosts } = await import("@/lib/blog");
+  const posts = await getAllPosts({ includeViews: false });
+  let filtered = posts;
+  if (args.tag) {
+    const lower = args.tag.toLowerCase();
+    filtered = filtered.filter((p) =>
+      p.tags.some((t) => t.toLowerCase() === lower),
+    );
+  }
+  if (args.query) {
+    const q = args.query.toLowerCase();
+    filtered = filtered.filter(
+      (p) =>
+        p.title.toLowerCase().includes(q) ||
+        p.excerpt.toLowerCase().includes(q) ||
+        p.tags.some((t) => t.toLowerCase().includes(q)),
+    );
+  }
+  const limit = Math.min(args.limit ?? 6, 12);
+  return filtered.slice(0, limit).map(toBlogPostSummary);
+}
+
+export async function getBlogPostBySlug(
+  slug: string,
+): Promise<BlogPostDetail | null> {
+  const { getPostBySlug } = await import("@/lib/blog");
+  try {
+    const post = await getPostBySlug(slug);
+    return toBlogPostDetail({
+      id: post.slug,
+      title: post.frontmatter.title,
+      excerpt: post.frontmatter.excerpt,
+      content: post.content,
+      author: post.frontmatter.author,
+      date: post.frontmatter.date,
+      tags: post.frontmatter.tags,
+      slug: post.slug,
+      views: post.views,
+      readingTime: post.readingTime,
+      published: true,
+      banner: post.frontmatter.banner,
+    });
+  } catch {
+    return null;
+  }
+}
+
+export function getCommunityInfo(): CommunityInfo {
+  return {
+    discord: "https://discord.gg/8ahXACdamN",
+    github: "https://github.com/VolvoxCommunity",
+    blog: `${SITE_URL}/blog`,
+    products: `${SITE_URL}/products`,
+    team: `${SITE_URL}/team`,
+    mentorshipPitch:
+      "Volvox pairs experienced developers with aspiring programmers through real-world open-source projects. The mentorship program has been running since 2018. Mentors include Bill Chirico (CEO) and Eleftheria Batsou (Developer Advocate).",
+    hiringEmail: "bill@volvox.dev",
+    siteUrl: SITE_URL,
+  };
+}

--- a/src/lib/ai/tools.ts
+++ b/src/lib/ai/tools.ts
@@ -1,0 +1,210 @@
+import { tool } from "ai";
+import { z } from "zod";
+import {
+  getBlogPostBySlug,
+  getCommunityInfo,
+  getProductBySlug,
+  getTeamMemberBySlug,
+  listBlogPosts,
+  listProducts,
+  listTeamMembers,
+} from "./tool-handlers";
+
+export const aiTools = {
+  get_team_members: tool({
+    description:
+      "List Volvox team members, optionally filtered by expertise, type (mentor, builder, marketer, mentee), or hireable status. Use this when the user asks about people on the team, who has a specific skill, or who is available for hire.",
+    inputSchema: z.object({
+      expertise: z
+        .array(z.string())
+        .optional()
+        .describe("Skill keywords to match, e.g. ['React', 'Next.js']"),
+      type: z
+        .enum(["mentor", "builder", "marketer", "mentee"])
+        .optional()
+        .describe("Filter by member type"),
+      isHireable: z
+        .boolean()
+        .optional()
+        .describe("If true, only return members marked as available for hire"),
+    }),
+    execute: async (args) => listTeamMembers(args),
+  }),
+
+  get_team_member: tool({
+    description:
+      "Fetch the full profile of a single Volvox team member by slug (bio, expertise, projects, contact). Use after get_team_members to drill into a specific person.",
+    inputSchema: z.object({
+      slug: z
+        .string()
+        .describe("The team member slug, e.g. 'rabden' or 'bill-chirico'"),
+    }),
+    execute: async ({ slug }) => getTeamMemberBySlug(slug),
+  }),
+
+  get_products: tool({
+    description:
+      "List all Volvox products with summary info (Sobers, Decision Jar). Use when the user asks what Volvox builds.",
+    inputSchema: z.object({}),
+    execute: async () => listProducts(),
+  }),
+
+  get_product: tool({
+    description:
+      "Fetch the full details of a single Volvox product by slug (description, features, tech stack, FAQ, links).",
+    inputSchema: z.object({
+      slug: z
+        .string()
+        .describe("The product slug, e.g. 'sobers' or 'decision-jar'"),
+    }),
+    execute: async ({ slug }) => getProductBySlug(slug),
+  }),
+
+  get_blog_posts: tool({
+    description:
+      "List Volvox blog posts, optionally filtered by tag or search query. Use when the user asks what Volvox has written about.",
+    inputSchema: z.object({
+      tag: z
+        .string()
+        .optional()
+        .describe("Filter by tag, e.g. 'Interview' or 'Community'"),
+      query: z
+        .string()
+        .optional()
+        .describe("Search keyword in title, excerpt, or tags"),
+      limit: z
+        .number()
+        .optional()
+        .describe("Max results to return (default 6, max 12)"),
+    }),
+    execute: async (args) => listBlogPosts(args),
+  }),
+
+  get_blog_post: tool({
+    description:
+      "Fetch the full content of a single Volvox blog post by slug. Returns an excerpt (first 600 chars of plain text) plus metadata.",
+    inputSchema: z.object({
+      slug: z.string().describe("The blog post slug, e.g. 'announcing-sobers'"),
+    }),
+    execute: async ({ slug }) => getBlogPostBySlug(slug),
+  }),
+
+  get_community_info: tool({
+    description:
+      "Get Volvox community info: Discord invite, GitHub org, hiring email, and the mentorship pitch. Use when the user asks how to join, collaborate, or hire.",
+    inputSchema: z.object({}),
+    execute: async () => getCommunityInfo(),
+  }),
+
+  surface_team_card: tool({
+    description:
+      "Render an inline clickable card for a team member inside the chat. Call this whenever you mention a specific person by name so the user can tap to view their profile / contact / hire them.",
+    inputSchema: z.object({
+      slug: z.string().describe("The team member slug"),
+      reason: z
+        .string()
+        .describe(
+          "One sentence explaining why this member is relevant to the user's question (shown in the card subtitle)",
+        ),
+    }),
+    execute: async ({ slug, reason }) => {
+      const member = getTeamMemberBySlug(slug);
+      if (!member) return { kind: "team" as const, slug, reason, found: false };
+      return {
+        kind: "team" as const,
+        slug,
+        reason,
+        found: true,
+        name: member.name,
+        role: member.role,
+        avatar: member.avatar,
+        profileUrl: member.profileUrl,
+        isHireable: member.isHireable,
+        tagline: member.tagline,
+      };
+    },
+  }),
+
+  surface_product_card: tool({
+    description:
+      "Render an inline clickable card for a Volvox product inside the chat. Call this whenever you mention a specific product (Sobers, Decision Jar) so the user can tap to learn more.",
+    inputSchema: z.object({
+      slug: z
+        .string()
+        .describe("The product slug, e.g. 'sobers' or 'decision-jar'"),
+      reason: z
+        .string()
+        .describe(
+          "One sentence explaining why this product is relevant to the user's question (shown in the card subtitle)",
+        ),
+    }),
+    execute: async ({ slug, reason }) => {
+      const product = getProductBySlug(slug);
+      if (!product)
+        return { kind: "product" as const, slug, reason, found: false };
+      return {
+        kind: "product" as const,
+        slug,
+        reason,
+        found: true,
+        name: product.name,
+        tagline: product.tagline,
+        pageUrl: product.pageUrl,
+        image: `/images/product/${product.slug === "sobers" ? "sobers.png" : "decision-jar/1.png"}`,
+      };
+    },
+  }),
+
+  surface_blog_card: tool({
+    description:
+      "Render an inline clickable card for a Volvox blog post inside the chat. Call this whenever you mention a specific blog post by title.",
+    inputSchema: z.object({
+      slug: z.string().describe("The blog post slug, e.g. 'announcing-sobers'"),
+      reason: z
+        .string()
+        .describe(
+          "One sentence explaining why this post is relevant to the user's question (shown in the card subtitle)",
+        ),
+    }),
+    execute: async ({ slug, reason }) => {
+      const post = await getBlogPostBySlug(slug);
+      if (!post) return { kind: "blog" as const, slug, reason, found: false };
+      return {
+        kind: "blog" as const,
+        slug,
+        reason,
+        found: true,
+        title: post.title,
+        excerpt: post.excerpt,
+        authorName: post.authorName,
+        readingTime: post.readingTime,
+        url: post.url,
+        banner: post.banner,
+      };
+    },
+  }),
+
+  report_intent: tool({
+    description:
+      "Report the assistant's read of the current user intent. The server already runs its own intent detector each turn — this tool lets the model communicate its own read for transparency. Safe to call once per turn, optional.",
+    inputSchema: z.object({
+      intent: z.enum(["beginner", "professional", "hirer"]),
+      confidence: z
+        .number()
+        .min(0)
+        .max(1)
+        .describe("How confident the assistant is in this intent (0-1)"),
+      reasoning: z
+        .string()
+        .optional()
+        .describe("Short note on what signals led to this read"),
+    }),
+    execute: async ({ intent, confidence, reasoning }) => ({
+      intent,
+      confidence,
+      reasoning: reasoning ?? "",
+    }),
+  }),
+} as const;
+
+export type AiTools = typeof aiTools;

--- a/src/lib/ai/tools.ts
+++ b/src/lib/ai/tools.ts
@@ -10,6 +10,67 @@ import {
   listTeamMembers,
 } from "./tool-handlers";
 
+const surfaceTeamCardOutputSchema = z.discriminatedUnion("found", [
+  z.object({
+    kind: z.literal("team"),
+    slug: z.string(),
+    reason: z.string(),
+    found: z.literal(true),
+    name: z.string(),
+    role: z.string(),
+    avatar: z.string(),
+    profileUrl: z.string(),
+    isHireable: z.boolean(),
+    tagline: z.string(),
+  }),
+  z.object({
+    kind: z.literal("team"),
+    slug: z.string(),
+    reason: z.string(),
+    found: z.literal(false),
+  }),
+]);
+
+const surfaceProductCardOutputSchema = z.discriminatedUnion("found", [
+  z.object({
+    kind: z.literal("product"),
+    slug: z.string(),
+    reason: z.string(),
+    found: z.literal(true),
+    name: z.string(),
+    tagline: z.string(),
+    pageUrl: z.string(),
+    image: z.string(),
+  }),
+  z.object({
+    kind: z.literal("product"),
+    slug: z.string(),
+    reason: z.string(),
+    found: z.literal(false),
+  }),
+]);
+
+const surfaceBlogCardOutputSchema = z.discriminatedUnion("found", [
+  z.object({
+    kind: z.literal("blog"),
+    slug: z.string(),
+    reason: z.string(),
+    found: z.literal(true),
+    title: z.string(),
+    excerpt: z.string(),
+    authorName: z.string(),
+    readingTime: z.number(),
+    url: z.string(),
+    banner: z.string().optional(),
+  }),
+  z.object({
+    kind: z.literal("blog"),
+    slug: z.string(),
+    reason: z.string(),
+    found: z.literal(false),
+  }),
+]);
+
 export const aiTools = {
   get_team_members: tool({
     description:
@@ -109,19 +170,29 @@ export const aiTools = {
     }),
     execute: async ({ slug, reason }) => {
       const member = getTeamMemberBySlug(slug);
-      if (!member) return { kind: "team" as const, slug, reason, found: false };
-      return {
-        kind: "team" as const,
-        slug,
-        reason,
-        found: true,
-        name: member.name,
-        role: member.role,
-        avatar: member.avatar,
-        profileUrl: member.profileUrl,
-        isHireable: member.isHireable,
-        tagline: member.tagline,
-      };
+      const raw: z.infer<typeof surfaceTeamCardOutputSchema> = member
+        ? {
+            kind: "team",
+            slug,
+            reason,
+            found: true,
+            name: member.name,
+            role: member.role,
+            avatar: member.avatar,
+            profileUrl: member.profileUrl,
+            isHireable: member.isHireable,
+            tagline: member.tagline,
+          }
+        : { kind: "team", slug, reason, found: false };
+      const result = surfaceTeamCardOutputSchema.safeParse(raw);
+      if (!result.success) {
+        console.warn(
+          "[surface_team_card] output validation failed",
+          result.error,
+        );
+        return { kind: "team", slug, reason, found: false };
+      }
+      return result.data;
     },
   }),
 
@@ -140,18 +211,27 @@ export const aiTools = {
     }),
     execute: async ({ slug, reason }) => {
       const product = getProductBySlug(slug);
-      if (!product)
-        return { kind: "product" as const, slug, reason, found: false };
-      return {
-        kind: "product" as const,
-        slug,
-        reason,
-        found: true,
-        name: product.name,
-        tagline: product.tagline,
-        pageUrl: product.pageUrl,
-        image: `/images/product/${product.slug === "sobers" ? "sobers.png" : "decision-jar/1.png"}`,
-      };
+      const raw: z.infer<typeof surfaceProductCardOutputSchema> = product
+        ? {
+            kind: "product",
+            slug,
+            reason,
+            found: true,
+            name: product.name,
+            tagline: product.tagline,
+            pageUrl: product.pageUrl,
+            image: product.image,
+          }
+        : { kind: "product", slug, reason, found: false };
+      const result = surfaceProductCardOutputSchema.safeParse(raw);
+      if (!result.success) {
+        console.warn(
+          "[surface_product_card] output validation failed",
+          result.error,
+        );
+        return { kind: "product", slug, reason, found: false };
+      }
+      return result.data;
     },
   }),
 
@@ -168,42 +248,30 @@ export const aiTools = {
     }),
     execute: async ({ slug, reason }) => {
       const post = await getBlogPostBySlug(slug);
-      if (!post) return { kind: "blog" as const, slug, reason, found: false };
-      return {
-        kind: "blog" as const,
-        slug,
-        reason,
-        found: true,
-        title: post.title,
-        excerpt: post.excerpt,
-        authorName: post.authorName,
-        readingTime: post.readingTime,
-        url: post.url,
-        banner: post.banner,
-      };
+      const raw: z.infer<typeof surfaceBlogCardOutputSchema> = post
+        ? {
+            kind: "blog",
+            slug,
+            reason,
+            found: true,
+            title: post.title,
+            excerpt: post.excerpt,
+            authorName: post.authorName,
+            readingTime: post.readingTime,
+            url: post.url,
+            banner: post.banner,
+          }
+        : { kind: "blog", slug, reason, found: false };
+      const result = surfaceBlogCardOutputSchema.safeParse(raw);
+      if (!result.success) {
+        console.warn(
+          "[surface_blog_card] output validation failed",
+          result.error,
+        );
+        return { kind: "blog", slug, reason, found: false };
+      }
+      return result.data;
     },
-  }),
-
-  report_intent: tool({
-    description:
-      "Report the assistant's read of the current user intent. The server already runs its own intent detector each turn — this tool lets the model communicate its own read for transparency. Safe to call once per turn, optional.",
-    inputSchema: z.object({
-      intent: z.enum(["beginner", "professional", "hirer"]),
-      confidence: z
-        .number()
-        .min(0)
-        .max(1)
-        .describe("How confident the assistant is in this intent (0-1)"),
-      reasoning: z
-        .string()
-        .optional()
-        .describe("Short note on what signals led to this read"),
-    }),
-    execute: async ({ intent, confidence, reasoning }) => ({
-      intent,
-      confidence,
-      reasoning: reasoning ?? "",
-    }),
   }),
 } as const;
 

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -1,0 +1,30 @@
+export type VisitorIntent = "beginner" | "professional" | "hirer";
+
+export type ChatRole = "user" | "assistant" | "system";
+
+export type SurfaceCardKind = "team" | "product" | "blog";
+
+export interface SurfaceCardData {
+  kind: SurfaceCardKind;
+  slug: string;
+  reason: string;
+}
+
+export interface ChatMessage {
+  id: string;
+  role: ChatRole;
+  content: string;
+  surfaceCards?: SurfaceCardData[];
+  createdAt: number;
+}
+
+export interface ChatRequestBody {
+  messages: { id: string; role: ChatRole; content: string }[];
+  intentSeed?: VisitorIntent | null;
+}
+
+export interface IntentDetectionResult {
+  intent: VisitorIntent;
+  confidence: number;
+  signals: { beginner: number; professional: number; hirer: number };
+}

--- a/tests/ai-chat-store.test.ts
+++ b/tests/ai-chat-store.test.ts
@@ -56,6 +56,44 @@ test("chat-store clears a chat", () => {
   assert.equal(loadChat(), null);
 });
 
+test("chat-store persists only user-facing message parts", () => {
+  memory.clear();
+  saveChat({
+    messages: [
+      {
+        id: "1",
+        role: "user",
+        parts: [{ type: "text", text: "Who can I hire?" }],
+      },
+      {
+        id: "2",
+        role: "assistant",
+        content: "Hossain is the best match.",
+        parts: [
+          { type: "tool-get_team_members", input: { isHireable: true } },
+          { type: "text", text: "Hossain is the best match." },
+          {
+            type: "tool-surface_team_card",
+            input: { slug: "rabden", reason: "Available for hire." },
+            output: { found: true, name: "Hossain Jahed" },
+          },
+        ],
+      },
+    ],
+    intent: "hirer",
+  });
+
+  const raw = memory.get("volvox-chat-history");
+  assert.ok(raw);
+  const parsed = JSON.parse(raw);
+  assert.equal(parsed.messages.length, 2);
+  assert.deepEqual(
+    parsed.messages[1].parts.map((part: { type: string }) => part.type),
+    ["text", "tool-surface_team_card"],
+  );
+  assert.equal(parsed.messages[0].content, "Who can I hire?");
+});
+
 test("chat-store expires after TTL", () => {
   memory.clear();
   saveChat({

--- a/tests/ai-chat-store.test.ts
+++ b/tests/ai-chat-store.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  clearChat,
+  getChatTtlDays,
+  loadChat,
+  saveChat,
+} from "../src/lib/ai/chat-store";
+
+const memory = new Map<string, string>();
+
+const mockStore = {
+  getItem: (k: string) => memory.get(k) ?? null,
+  setItem: (k: string, v: string) => {
+    memory.set(k, v);
+  },
+  removeItem: (k: string) => {
+    memory.delete(k);
+  },
+  clear: () => memory.clear(),
+  key: () => null,
+  length: 0,
+};
+
+Object.defineProperty(globalThis, "localStorage", {
+  value: mockStore,
+  configurable: true,
+});
+
+test("chat-store returns null when nothing is stored", () => {
+  memory.clear();
+  assert.equal(loadChat(), null);
+});
+
+test("chat-store saves and loads a chat", () => {
+  memory.clear();
+  saveChat({
+    messages: [{ id: "1", role: "user", content: "hi" }],
+    intent: "beginner",
+  });
+  const loaded = loadChat();
+  assert.ok(loaded);
+  assert.equal(loaded?.messages.length, 1);
+  assert.equal(loaded?.intent, "beginner");
+  assert.ok((loaded?.expiresAt ?? 0) > Date.now());
+});
+
+test("chat-store clears a chat", () => {
+  memory.clear();
+  saveChat({
+    messages: [{ id: "1", role: "user", content: "hi" }],
+    intent: null,
+  });
+  clearChat();
+  assert.equal(loadChat(), null);
+});
+
+test("chat-store expires after TTL", () => {
+  memory.clear();
+  saveChat({
+    messages: [{ id: "1", role: "user", content: "hi" }],
+    intent: "professional",
+  });
+  const loaded = loadChat();
+  assert.ok(loaded);
+  if (loaded) {
+    memory.clear();
+    const expiredPayload = JSON.stringify({
+      ...loaded,
+      expiresAt: Date.now() - 1000,
+    });
+    memory.set("volvox-chat-history", expiredPayload);
+    assert.equal(loadChat(), null);
+  }
+});
+
+test("chat-store TTL is 14 days", () => {
+  assert.equal(getChatTtlDays(), 14);
+});

--- a/tests/ai-intent.test.ts
+++ b/tests/ai-intent.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { detectIntent } from "../src/lib/ai/intent";
+
+test("detectIntent returns professional by default for empty input", () => {
+  const result = detectIntent([]);
+  assert.equal(result.intent, "professional");
+});
+
+test("detectIntent detects beginner signals", () => {
+  const result = detectIntent([
+    { role: "user", content: "I'm just starting to learn to code" },
+  ]);
+  assert.equal(result.intent, "beginner");
+});
+
+test("detectIntent detects hirer signals", () => {
+  const result = detectIntent([
+    { role: "user", content: "We're hiring a frontend developer for our team" },
+  ]);
+  assert.equal(result.intent, "hirer");
+});
+
+test("detectIntent detects professional signals", () => {
+  const result = detectIntent([
+    { role: "user", content: "How can I contribute to the open source repo?" },
+  ]);
+  assert.equal(result.intent, "professional");
+});
+
+test("detectIntent shifts intent based on latest message", () => {
+  const result = detectIntent([
+    { role: "user", content: "I'm a beginner" },
+    { role: "user", content: "actually I'm looking to hire" },
+  ]);
+  assert.equal(result.intent, "hirer");
+});
+
+test("detectIntent boosts explicit seed", () => {
+  const result = detectIntent([{ role: "user", content: "Hello there" }], {
+    explicitSeed: "beginner",
+  });
+  assert.equal(result.intent, "beginner");
+  assert.ok(result.confidence > 0);
+});
+
+test("detectIntent ignores non-user messages", () => {
+  const result = detectIntent([
+    { role: "assistant", content: "I am a beginner" },
+    { role: "user", content: "Hi" },
+  ]);
+  assert.equal(result.intent, "professional");
+});
+
+test("detectIntent returns bounded confidence", () => {
+  const result = detectIntent([
+    { role: "user", content: "hire react developer" },
+  ]);
+  assert.ok(result.confidence > 0);
+  assert.ok(result.confidence <= 1);
+});

--- a/tests/ai-system-prompt.test.ts
+++ b/tests/ai-system-prompt.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ctaFor } from "../src/lib/ai/cta-bank";
+import { detectIntent } from "../src/lib/ai/intent";
+import { buildSystemPrompt } from "../src/lib/ai/system-prompt";
+import type { VisitorIntent } from "../src/lib/ai/types";
+
+const ALL_INTENTS: VisitorIntent[] = ["beginner", "professional", "hirer"];
+
+test("buildSystemPrompt includes the master preamble for every persona", () => {
+  for (const intent of ALL_INTENTS) {
+    const prompt = buildSystemPrompt(intent);
+    assert.ok(prompt.includes("Volvox Assistant"));
+    assert.ok(prompt.includes("Sobers"));
+    assert.ok(prompt.includes("Decision Jar"));
+  }
+});
+
+test("buildSystemPrompt includes beginner persona block", () => {
+  const prompt = buildSystemPrompt("beginner");
+  assert.ok(prompt.includes("Persona: BEGINNER"));
+  assert.ok(prompt.toLowerCase().includes("warm"));
+});
+
+test("buildSystemPrompt includes hirer persona block", () => {
+  const prompt = buildSystemPrompt("hirer");
+  assert.ok(prompt.includes("Persona: HIRER"));
+  assert.ok(prompt.toLowerCase().includes("direct"));
+});
+
+test("buildSystemPrompt includes professional persona block", () => {
+  const prompt = buildSystemPrompt("professional");
+  assert.ok(prompt.includes("Persona: PROFESSIONAL"));
+  assert.ok(prompt.toLowerCase().includes("peer"));
+});
+
+test("buildSystemPrompt always includes tool guidance", () => {
+  const prompt = buildSystemPrompt("professional");
+  assert.ok(prompt.includes("get_team_members"));
+  assert.ok(prompt.includes("get_products"));
+  assert.ok(prompt.includes("get_blog_posts"));
+});
+
+test("ctaFor returns a CTA for each persona", () => {
+  for (const intent of ALL_INTENTS) {
+    const cta = ctaFor(intent);
+    assert.ok(cta.welcomeIntro);
+    assert.ok(cta.fallback());
+    assert.ok(cta.afterTeamMember("Test").includes("Test"));
+  }
+});
+
+test("beginner CTA prefers Discord", () => {
+  const cta = ctaFor("beginner");
+  assert.ok(cta.fallback().toLowerCase().includes("discord"));
+});
+
+test("hirer CTA prefers email", () => {
+  const cta = ctaFor("hirer");
+  assert.ok(cta.fallback().includes("bill@volvox.dev"));
+});
+
+test("detects beginner from text and composes beginner prompt", () => {
+  const text = "I'm new to coding and want to learn";
+  const result = detectIntent([{ role: "user", content: text }]);
+  assert.equal(result.intent, "beginner");
+  const prompt = buildSystemPrompt(result.intent);
+  assert.ok(prompt.includes("Persona: BEGINNER"));
+});
+
+test("detects hirer from text and composes hirer prompt", () => {
+  const text = "Looking to hire a developer for our team";
+  const result = detectIntent([{ role: "user", content: text }]);
+  assert.equal(result.intent, "hirer");
+  const prompt = buildSystemPrompt(result.intent);
+  assert.ok(prompt.includes("Persona: HIRER"));
+});
+
+test("tool handlers return data for valid slugs", async () => {
+  const { getTeamMemberBySlug } = await import("../src/lib/ai/tool-handlers");
+  const member = getTeamMemberBySlug("bill-chirico");
+  assert.ok(member);
+  assert.equal(member?.name, "Bill Chirico");
+});
+
+test("tool handlers return data for product slugs", async () => {
+  const { getProductBySlug } = await import("../src/lib/ai/tool-handlers");
+  const product = getProductBySlug("sobers");
+  assert.ok(product);
+  assert.equal(product?.name, "Sobers");
+});
+
+test("tool handlers list team members", async () => {
+  const { listTeamMembers } = await import("../src/lib/ai/tool-handlers");
+  const members = listTeamMembers();
+  assert.ok(members.length > 0);
+});
+
+test("tool handlers list products", async () => {
+  const { listProducts } = await import("../src/lib/ai/tool-handlers");
+  const products = listProducts();
+  assert.ok(products.length > 0);
+});


### PR DESCRIPTION
## Summary

Adds an AI-powered chat assistant to the Volvox website featuring intent-aware conversation, tool-based data retrieval, and a dual-mode (floating + full-page) UI.

## Key Features

- **Intent Detection** — per-turn classification as beginner/professional/hirer with confidence scoring and recency boost
- **Persona-Adaptive Responses** — system prompt shifts per detected intent (Discord for beginners, portfolio for professionals, email for hirers)
- **Tool Integration** — 11 AI tools wrapping `src/lib/content.ts` for team, product, blog, community data
- **Dual Interface** — floating widget (every page) + dedicated `/chat` page with `?intent=` and `?q=` URL params
- **Persistence** — 14-day localStorage with explicit clear
- **Rate Limiting** — 20 turns / 10 min via Upstash Redis (falls through gracefully)
- **Streaming** — multi-step (`stepCountIs(6)`) with per-step tool call deduplication, thinking indicators, and progressive card rendering

## Implementation Details

- Uses `@ai-sdk/openai-compatible` with OpenRouter (free tier: `moonshotai/kimi-k2.6:free`); Z.AI GLM 4.5 configured in code (commented) for production
- All content sourced from Zod-validated schemas in `src/lib/schemas.ts`
- Follows project conventions: Biome lint, Tailwind v4, Framer Motion, Phosphor icons, Server/Client Component pattern

## Testing

- 33 unit tests (intent detection, chat store, system prompt, content integration)
- All pre-commit checks passing: format, typecheck, lint, test (33/33), build (34 pages)

## Notes

- Add `OPENROUTER_API_KEY` to `.env` from https://openrouter.ai/keys to enable real AI responses
- For production, uncomment Z.AI block in `src/lib/ai/provider.ts` and set `Z_AI_API_KEY`