### PR TITLE
Hotfix: SSR HTML rendering issue on dev mode

### DIFF
--- a/src/components/blog/blog-post-header.tsx
+++ b/src/components/blog/blog-post-header.tsx
@@ -58,17 +58,12 @@ export function BlogPostHeader() {
                 variant="ghost"
                 size="icon"
                 onClick={toggleTheme}
-                aria-label={
-                  resolvedTheme === "light"
-                    ? "Switch to dark mode"
-                    : "Switch to light mode"
-                }
+                aria-label="Toggle theme"
               >
-                {resolvedTheme === "light" ? (
-                  <Moon weight="fill" className="h-5 w-5" />
-                ) : (
-                  <Sun weight="fill" className="h-5 w-5" />
-                )}
+                {/* Both icons render on the server; the `.dark` class decides
+                    which is visible, so SSR and hydration always match. */}
+                <Moon weight="fill" className="h-5 w-5 block dark:hidden" />
+                <Sun weight="fill" className="h-5 w-5 hidden dark:block" />
               </Button>
             </motion.div>
 

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -261,11 +261,10 @@ export function Navigation(props: NavigationProps) {
               aria-label="Toggle theme"
               data-testid="nav-theme-toggle"
             >
-              {resolvedTheme === "light" ? (
-                <Moon weight="fill" className="h-5 w-5" />
-              ) : (
-                <Sun weight="fill" className="h-5 w-5" />
-              )}
+              {/* Both icons render on the server; the `.dark` class decides
+                  which is visible, so SSR and hydration always match. */}
+              <Moon weight="fill" className="h-5 w-5 block dark:hidden" />
+              <Sun weight="fill" className="h-5 w-5 hidden dark:block" />
             </Button>
 
             <Button


### PR DESCRIPTION
## Summary

Fixes a React hydration mismatch thrown by the theme-toggle button in the site navigation.

`useTheme()` from `next-themes` returns `resolvedTheme === undefined` during SSR - the active theme lives in `localStorage` and isn't knowable until the client script runs. Both toggle buttons branched on it at render time:

```tsx
{resolvedTheme === "light" ? <Moon /> : <Sun />}
```

So the server always took the `Sun` branch, while the client's first render resolved the real theme and produced `Moon`. Same element, different `<path d=...>` → hydration mismatch.

```
A tree hydrated but some attributes of the server rendered HTML didn't match
the client properties. This won't be patched up.
```

## Fix

Render both icons unconditionally and let the `.dark` class on `<html>` decide which is visible. `next-themes` sets that class via a pre-paint inline script, so the correct icon is showing before first paint — no flash, and the server and client HTML are byte-identical.

```tsx
<Moon weight="fill" className="h-5 w-5 block dark:hidden" />
<Sun  weight="fill" className="h-5 w-5 hidden dark:block" />
```

This is the same SSR-safe pattern already used by `ThemeToggle` in `src/components/theme-toggle.tsx` and by the light/dark logo swap in `src/components/products/product-hero.tsx` — this PR brings the two remaining holdouts in line with it.

`toggleTheme` still reads `resolvedTheme`, which is correct: it only runs on click, long after mount.

## Changes

- **`src/components/navigation.tsx`** — the component in the reported stack trace. CSS-based icon swap.
- **`src/components/blog/blog-post-header.tsx`** — same latent bug, plus its `aria-label` branched on `resolvedTheme` too (an attribute-level mismatch on top of the element one); now a static `"Toggle theme"`. Note this component currently has no importers, so the fix is pre-emptive.

## Notes

- Despite the branch name, this is **not dev-only**. Production SSR hits the same mismatch; React just logs a terser message there instead of the full diff.
- `src/components/ui/sonner.tsx` also reads `resolvedTheme`, but Sonner's `Toaster` renders nothing server-side, so it is not a mismatch source. Left alone.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — no new findings in the touched files (pre-existing warnings elsewhere are unrelated)
- Served HTML from the dev server now contains **both** icon paths with `block dark:hidden` / `hidden dark:block`, confirming the server output no longer depends on `resolvedTheme`
- Console hydration error no longer reproduces on load
